### PR TITLE
[release/6.0-preview4] Set tooling paths correctly

### DIFF
--- a/eng/sdk_files/Emscripten.Node.props
+++ b/eng/sdk_files/Emscripten.Node.props
@@ -1,5 +1,11 @@
 <Project>
   <PropertyGroup>
     <EmscriptenNodeToolsPath>$(MSBuildThisFileDirectory)..\tools\</EmscriptenNodeToolsPath>
+    <EmscriptenNodeBinPath>$(EmscriptenNodeToolsPath)bin\</EmscriptenNodeBinPath>
+
   </PropertyGroup>
+
+  <ItemGroup>
+    <_EmscriptenAddPATH Include="$(EmscriptenNodeBinPath)" />
+  </ItemGroup>
 </Project>

--- a/eng/sdk_files/Emscripten.Python.props
+++ b/eng/sdk_files/Emscripten.Python.props
@@ -1,5 +1,13 @@
 <Project>
   <PropertyGroup>
     <EmscriptenPythonToolsPath>$(MSBuildThisFileDirectory)..\tools\</EmscriptenPythonToolsPath>
+
+    <EmscriptenPythonBinPath Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonToolsPath)bin\</EmscriptenPythonBinPath>
+    <!-- On windows, emsdk has python binary in the tools folder, instead of `bin/` -->
+    <EmscriptenPythonBinPath Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonToolsPath)</EmscriptenPythonBinPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <_EmscriptenAddPATH Include="$(EmscriptenPythonBinPath)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Simplified Preview4 fix for https://github.com/dotnet/runtime/issues/51535 in release/6.0-preview4 where the tooling paths were not setup correctly

## Customer Impact
Normal Blazor AOT build in preview4 will fail to find the packaged tooling

## Testing
Tested locally

## Risk
Very low, AOT build related only tooling fix