### PR TITLE
[wasm] Add the paths to binaries, to `@(EmscriptenPrependPath)`

### DIFF
--- a/eng/sdk_files/Emscripten.Node.props
+++ b/eng/sdk_files/Emscripten.Node.props
@@ -3,4 +3,8 @@
     <EmscriptenNodeToolsPath>$(MSBuildThisFileDirectory)..\tools\</EmscriptenNodeToolsPath>
     <EmscriptenNodeBinPath>$(EmscriptenNodeToolsPath)bin\</EmscriptenNodeBinPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <EmscriptenPrependPATH Include="$(EmscriptenNodeBinPath)" />
+  </ItemGroup>
 </Project>

--- a/eng/sdk_files/Emscripten.Python.props
+++ b/eng/sdk_files/Emscripten.Python.props
@@ -6,4 +6,8 @@
     <!-- On windows, emsdk has python binary in the tools folder, instead of `bin/` -->
     <EmscriptenPythonBinPath Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonToolsPath)</EmscriptenPythonBinPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <EmscriptenPrependPATH Include="$(EmscriptenPythonBinPath)" />
+  </ItemGroup>
 </Project>

--- a/eng/sdk_files/Emscripten.Sdk.props
+++ b/eng/sdk_files/Emscripten.Sdk.props
@@ -1,6 +1,12 @@
 <Project>
-    <PropertyGroup>
-        <EmscriptenSdkToolsPath>$(MSBuildThisFileDirectory)..\tools\</EmscriptenSdkToolsPath>
-        <EmSdkUpstreamBinPath>$(EmscriptenSdkToolsPath)bin\</EmSdkUpstreamBinPath>
-    </PropertyGroup>
+  <PropertyGroup>
+    <EmscriptenSdkToolsPath>$(MSBuildThisFileDirectory)..\tools\</EmscriptenSdkToolsPath>
+    <EmscriptenUpstreamBinPath>$(EmscriptenSdkToolsPath)bin\</EmscriptenUpstreamBinPath>
+    <EmscriptenUpstreamEmscriptenPath>$(EmscriptenSdkToolsPath)emscripten\</EmscriptenUpstreamEmscriptenPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmscriptenPrependPATH Include="$(EmscriptenUpstreamBinPath)" />
+    <EmscriptenPrependPATH Include="$(EmscriptenUpstreamEmscriptenPath)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Instead of depending on `WasmApp.targets` to set the `PATH` using the correct properties, add them directory to `@(EmscriptenPrependPath)`, which will get added to `PATH`.