### PR TITLE
Set `EMSDK_PYTHON=../python3` to match what `emsdk_env.sh` does

### DIFF
--- a/eng/sdk_files/Emscripten.Python.props
+++ b/eng/sdk_files/Emscripten.Python.props
@@ -9,5 +9,6 @@
 
   <ItemGroup>
     <EmscriptenPrependPATH Include="$(EmscriptenPythonBinPath)" />
+    <EmscriptenEnvVars Include="EMSDK_PYTHON=$(EmscriptenPythonBinPath)\python3" />
   </ItemGroup>
 </Project>

--- a/eng/sdk_files/Emscripten.Python.props
+++ b/eng/sdk_files/Emscripten.Python.props
@@ -5,10 +5,13 @@
     <EmscriptenPythonBinPath Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonToolsPath)bin\</EmscriptenPythonBinPath>
     <!-- On windows, emsdk has python binary in the tools folder, instead of `bin/` -->
     <EmscriptenPythonBinPath Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonToolsPath)</EmscriptenPythonBinPath>
-  </PropertyGroup>
 
-  <ItemGroup>
-    <EmscriptenPrependPATH Include="$(EmscriptenPythonBinPath)" />
-    <EmscriptenEnvVars Include="EMSDK_PYTHON=$(EmscriptenPythonBinPath)\python3" />
+    <_EmscriptenPython Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonBinPath)\python3</_EmscriptenPython>
+    <_EmscriptenPython Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))" >$(EmscriptenPythonBinPath)\python.exe</_EmscriptenPython>
+   </PropertyGroup>
+
+   <ItemGroup>
+     <EmscriptenPrependPATH Include="$(EmscriptenPythonBinPath)" />
+     <EmscriptenEnvVars Include="EMSDK_PYTHON=$(_EmscriptenPython)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We add the path containing the python binaries from the packages to
`PATH`, but that contains `python3`, and not `python`. When we run
`emcc --version` on a machine without a system python, it fails with

    `unable to find python in $PATH`

This was not caught with our regular testing, possibly because a system
`python` was available on those machines.

`emsdk_env.sh` sets `EMSDK_PYTHON = /Users/radical/dev/r3/src/mono/wasm/emsdk/python/3.7.4-2_64bit/bin/python3`

.. so, this commit adds the same for running `emcc`, and sets that to
`python3` from the package.

This was tested on macOS.