### PR TITLE
[backport release/6.0-preview5] Set `EMSDK_PYTHON=../python3` to match what `emsdk_env.sh` does (#19)

### DIFF
--- a/eng/sdk_files/Emscripten.Python.props
+++ b/eng/sdk_files/Emscripten.Python.props
@@ -5,9 +5,13 @@
     <EmscriptenPythonBinPath Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonToolsPath)bin\</EmscriptenPythonBinPath>
     <!-- On windows, emsdk has python binary in the tools folder, instead of `bin/` -->
     <EmscriptenPythonBinPath Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonToolsPath)</EmscriptenPythonBinPath>
-  </PropertyGroup>
 
-  <ItemGroup>
-    <EmscriptenPrependPATH Include="$(EmscriptenPythonBinPath)" />
+    <_EmscriptenPython Condition="!$([MSBuild]::IsOSPlatform('WINDOWS'))">$(EmscriptenPythonBinPath)\python3</_EmscriptenPython>
+    <_EmscriptenPython Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))" >$(EmscriptenPythonBinPath)\python.exe</_EmscriptenPython>
+   </PropertyGroup>
+
+   <ItemGroup>
+     <EmscriptenPrependPATH Include="$(EmscriptenPythonBinPath)" />
+     <EmscriptenEnvVars Include="EMSDK_PYTHON=$(_EmscriptenPython)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
(cherry picked from commit 80b4baa20e3c0c33a6d17dae28cdec6ccf39e0ee)