### PR TITLE
Recent releases use clang++

### DIFF
--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -91,7 +91,7 @@
     <Delete Files="$(ArtifactsObjDir)node\bin\npx" />
 
     <!-- on Windows these are identical copies that should be symlinks, remove them for now -->
-    <Delete Files="$(ArtifactsObjDir)upstream\bin\clang++.exe" />
+    <!--<Delete Files="$(ArtifactsObjDir)upstream\bin\clang++.exe" /> Used by .32 directly -->
     <Delete Files="$(ArtifactsObjDir)upstream\bin\wasm32-clang++.exe" />
     <Delete Files="$(ArtifactsObjDir)upstream\bin\wasm32-clang.exe" />
     <Delete Files="$(ArtifactsObjDir)upstream\bin\wasm32-wasi-clang.exe" />

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -91,7 +91,7 @@
     <Delete Files="$(ArtifactsObjDir)node\bin\npx" />
 
     <!-- on Windows these are identical copies that should be symlinks, remove them for now -->
-    <!--<Delete Files="$(ArtifactsObjDir)upstream\bin\clang++.exe" /> Used by .32 directly -->
+    <!--<Delete Files="$(ArtifactsObjDir)upstream\bin\clang++.exe" /> Used by .23 directly -->
     <Delete Files="$(ArtifactsObjDir)upstream\bin\wasm32-clang++.exe" />
     <Delete Files="$(ArtifactsObjDir)upstream\bin\wasm32-clang.exe" />
     <Delete Files="$(ArtifactsObjDir)upstream\bin\wasm32-wasi-clang.exe" />


### PR DESCRIPTION
we need to test the workloads in use before upgrading too.

On windows, `emcc` ends up invoking `"C:\Program Files\dotnet\packs\Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.win-x64\6.0.0-preview.7.21323.1\tools\bin\clang++.exe"`, but that file is missing on the sdk package.

And that manifests as:

```
       WasmApp.Native.targets(268,5): error : Failed to compile C:\dev\bl1\obj\Debug\net6.0\wasm\System.Private.Uri.dll.bc -> C:\dev\bl1\obj\Debug\net6.0\wasm\System.Private.Uri.dll.o: C:\dev\bl1>setlocal [C:\dev\bl1\bl1.csproj]
       WasmApp.Native.targets(268,5): error : C:\dev\bl1>set errorlevel=dummy  [C:\dev\bl1\bl1.csproj]
       WasmApp.Native.targets(268,5): error : C:\dev\bl1>set errorlevel=  [C:\dev\bl1\bl1.csproj]
       WasmApp.Native.targets(268,5): error : C:\dev\bl1>emcc "@c:\dev\.nuget\microsoft.netcore.app.runtime.mono.browser-wasm\6.0.0-preview.7.21329.1\runtimes\browser-wasm\native\src\emcc-default.rsp" -O0 -s DISABLE_EXCEPTION_CATCHING=0 -v -s TOTAL_MEMORY=536870912 -c -o C:\dev\bl1\obj\Debug\net6.0\wasm\System.Private.Uri.dll.o C:\dev\bl1\obj\Debug\net6.0\wasm\System.Private.Uri.dll.bc  [C:\dev\bl1\bl1.csproj]
       WasmApp.Native.targets(268,5): error :  "C:\Program Files\dotnet\packs\Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.win-x64\6.0.0-preview.7.21323.1\tools\bin\clang++.exe" -target wasm32-unknown-emscripten -DEMSCRIPTEN -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -D__EMSCRIPTEN_major__=2 -D__EMSCRIPTEN_minor__=0 -D__EMSCRIPTEN_tiny__=23 -D_LIBCPP_ABI_VERSION=2 -Dunix -D__unix -D__unix__ -Werror=implicit-function-declaration -Xclang -iwithsysroot/include/SDL "--sysroot=C:\Program Files\dotnet\packs\Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.win-x64\6.0.0-preview.7.21323.1\tools\emscripten\cache\sysroot" -Xclang -iwithsysroot/include\compat -emit-llvm -O0 -v -c C:\dev\bl1\obj\Debug\net6.0\wasm\System.Private.Uri.dll.bc -o C:\dev\bl1\obj\Debug\net6.0\wasm\System.Private.Uri.dll.o [C:\dev\bl1\bl1.csproj]

       WasmApp.Native.targets(268,5): error : emcc: error: '"C:\Program Files\dotnet\packs\Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.win-x64\6.0.0-preview.7.21323.1\tools\bin\clang++.exe" -target wasm32-unknown-emscripten -DEMSCRIPTEN -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -D__EMSCRIPTEN_major__=2 -D__EMSCRIPTEN_minor__=0 -D__EMSCRIPTEN_tiny__=23 -D_LIBCPP_ABI_VERSION=2 -Dunix -D__unix -D__unix__ -Werror=implicit-function-declaration -Xclang -iwithsysroot/include/SDL "--sysroot=C:\Program Files\dotnet\packs\Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.win-x64\6.0.0-preview.7.21323.1\tools\emscripten\cache\sysroot" -Xclang -iwithsysroot/include\compat -emit-llvm -O0 -v -c C:\dev\bl1\obj\Debug\net6.0\wasm\System.Private.Uri.dll.bc -o C:\dev\bl1\obj\Debug\net6.0\wasm\System.Private.Uri.dll.o' failed: [WinError 2] The system cannot find the file specified
```