### PR TITLE
Allow `FROZEN_CACHE` to be overridden by user projects

### DIFF
--- a/eng/.emscripten
+++ b/eng/.emscripten
@@ -4,7 +4,7 @@ LLVM_ROOT = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_LLVM_ROOT', ''))
 NODE_JS = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_NODE_JS', ''))
 BINARYEN_ROOT = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_BINARYEN_ROOT', ''))
 
-FROZEN_CACHE = os.path.expanduser(os.getenv('FROZEN_CACHE', 'True'))
+FROZEN_CACHE = bool(os.getenv('FROZEN_CACHE', 'True'))
 
 COMPILER_ENGINE = NODE_JS
 JS_ENGINES = [NODE_JS]

--- a/eng/.emscripten
+++ b/eng/.emscripten
@@ -4,7 +4,7 @@ LLVM_ROOT = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_LLVM_ROOT', ''))
 NODE_JS = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_NODE_JS', ''))
 BINARYEN_ROOT = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_BINARYEN_ROOT', ''))
 
-FROZEN_CACHE = True
+FROZEN_CACHE = os.path.expanduser(os.getenv('FROZEN_CACHE', 'True'))
 
 COMPILER_ENGINE = NODE_JS
 JS_ENGINES = [NODE_JS]


### PR DESCRIPTION
This would allow this to be overridden when we are trying to use local per-project caches.