### PR TITLE
Delete selected libs from cache to shrink size

### DIFF
--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -106,7 +106,7 @@
     <Delete Files="$(ArtifactsObjDir)upstream\emscripten\third_party\*.*" />
     <!--<Delete Files="$(ArtifactsObjDir)upstream\bin\wasm-ld.exe" />--> <!-- TODO: this is used by emcc but could be a symlink to ld.exe -->
 
-    <ItemGroup Condition="'$(PackageRID)' == 'win-x64'">
+    <ItemGroup>
       <!-- delete these libs from the cache to reduce windows nuget size context: https://github.com/dotnet/emsdk/pull/34#issuecomment-872691739 -->
       <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_js.a" />
       <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_rt-mt.a" />

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -127,7 +127,8 @@
       <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_minimal_rt_wasm.a" />
       <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt-mt.a" />
       <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libemmalloc*.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\lib*-mt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\lib*-mt-*.a" />
     </ItemGroup>
     <Delete Files="@(DeleteCacheFiles)" />
 

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -127,6 +127,7 @@
       <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_minimal_rt_wasm.a" />
       <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt-mt.a" />
       <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libemmalloc*.a" />
     </ItemGroup>
     <Delete Files="@(DeleteCacheFiles)" />
 

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -106,6 +106,30 @@
     <Delete Files="$(ArtifactsObjDir)upstream\emscripten\third_party\*.*" />
     <!--<Delete Files="$(ArtifactsObjDir)upstream\bin\wasm-ld.exe" />--> <!-- TODO: this is used by emcc but could be a symlink to ld.exe -->
 
+    <ItemGroup Condition="'$(PackageRID)' == 'win-x64'">
+      <!-- delete these libs from the cache to reduce windows nuget size context: https://github.com/dotnet/emsdk/pull/34#issuecomment-872691739 -->
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_js.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_rt-mt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_rt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libc_rt_wasm-asan-optz.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libc_rt_wasm-asan.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libc-asan.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libc-mt-asan.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_common_rt-mt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_common_rt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_rt-mt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_rt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libprintf_long_double-asan.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libprintf_long_double-mt-asan.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libsanitizer_common_rt-mt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libsanitizer_common_rt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_minimal_rt_wasm-mt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_minimal_rt_wasm.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt-mt.a" />
+      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt.a" />
+    </ItemGroup>
+    <Delete Files="@(DeleteCacheFiles)" />
+
     <!-- Strip binaries -->
     <ItemGroup>
       <UpstreamBinFiles Include="$(ArtifactsObjDir)upstream\bin\*" />


### PR DESCRIPTION
Delete these libs on windows, where we are over the nuget size limit.
Context: https://github.com/dotnet/emsdk/pull/34#issuecomment-872691739

That should affect build times when using
[debug sanitizers](https://emscripten.org/docs/debugging/Sanitizers.html)
which is not used by default builds.

Also remove `mt` libs. We don't support threads yet anyway.