### PR TITLE
[release/6.0-preview7] Build VS installers for EMSDK workloads

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ProjectToBuild Include="$(MSBuildThisFileDirectory)emsdk.proj" />
+    <ProjectToBuild BuildInParallel="false" Condition="'$(SkipBuild)' != 'true'" Include="$(MSBuildThisFileDirectory)emsdk.proj" />
+    <ProjectToBuild BuildInParallel="false" Condition="'$(AssetManifestOS)' == 'win' and '$(SkipWorkloads)' != 'true'" Include="$(MSBuildThisFileDirectory)\workloads\workloads.csproj" />
   </ItemGroup>
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -5,4 +5,22 @@
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages> <!-- we don't need symbol packages for emsdk -->
       <PostBuildSign>true</PostBuildSign>
    </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers</PublishDependsOnTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <_InstallersToPublish Include="$(ArtifactsDir)**\*.wixpack.zip" UploadPathSegment="wixpack" />
+  </ItemGroup>
+
+  <Target Name="_PublishInstallers">
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
+        <IsShipping>true</IsShipping>
+        <PublishFlatContainer>true</PublishFlatContainer>
+        <RelativeBlobPath>$(_UploadPathRoot)/%(_InstallersToPublish.UploadPathSegment)/$(_PackageVersion)/%(Filename)%(Extension)</RelativeBlobPath>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,13 @@
     <WorkloadSdkBandVersion>6.0.100</WorkloadSdkBandVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21364.3</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.21364.3</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21366.1</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.21366.1</MicrosoftDotNetBuildTasksTemplatingVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>6.0.0-beta.21366.1</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.21366.1</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>
+    <WixPackageVersion>3.14.0-dotnet</WixPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -69,13 +69,37 @@ stages:
           vmImage: windows-2019
         steps:
         - script: |
-            .\build.cmd -ci -configuration $(_BuildConfig) $(_InternalPublishArg) /p:PackageRID=win-x64 /p:AssetManifestOS=win /p:PlatformName=x64 $(_InternalBuildArgs)
+            .\build.cmd -ci -configuration $(_BuildConfig) $(_InternalPublishArg) /p:PackageRID=win-x64 /p:AssetManifestOS=win /p:PlatformName=x64 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping $(_InternalBuildArgs)
           displayName: Build and Publish
         - publish: artifacts/packages
           artifact: Packages_Windows
         - script: |
             rmdir /s /q upstream node python
           displayName: Remove temporary artifacts
+        # Upload packages wrapping msis
+        - task: CopyFiles@2
+          displayName: Prepare job-specific intermediate artifacts subdirectory
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+            Contents: |
+              Shipping/**/*
+              NonShipping/**/*
+            TargetFolder: '$(Build.StagingDirectory)/IntermediateArtifacts/workloads'
+            CleanTargetFolder: true
+        # Delete wixpdb files before they are uploaded to artifacts
+        - task: DeleteFiles@1
+          displayName: Delete wixpdb's
+          inputs:
+            SourceFolder: $(Build.SourcesDirectory)/artifacts/workloadPackages
+            Contents: '*.wixpdb'
+        # Upload artifacts to be used for generating VS components
+        - task: PublishPipelineArtifact@1
+          displayName: Publish workload artifacts
+          inputs:
+            targetPath: $(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)/Insertion/
+            artifactName: 'Workloads'
+          continueOnError: true
+          condition: always()
 
 ############ POST BUILD ARCADE LOGIC ############
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -147,7 +147,7 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Node\Microsoft.NET.Runtime.Emscripten.Node.pkgproj" Targets="Build" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Python\Microsoft.NET.Runtime.Emscripten.Python.pkgproj" Targets="Build" Condition="'$(UsesPythonFromEmsdk)' == 'true'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk\Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj" Targets="Build" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Manifest\Microsoft.NET.Workload.Emscripten.Manifest.pkgproj" Targets="Build" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'osx'" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Manifest\Microsoft.NET.Workload.Emscripten.Manifest.pkgproj" Targets="Build" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'win'" />
   </Target>
   <Import Project="$(RepoRoot)\Directory.Build.targets" />
 </Project>

--- a/eng/workloads/Directory.Build.props
+++ b/eng/workloads/Directory.Build.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+</Project>

--- a/eng/workloads/VSSetup.props
+++ b/eng/workloads/VSSetup.props
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <VSSetupProps>1</VSSetupProps>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <VSDropServiceUri>https://vsdrop.corp.microsoft.com/file/v1/</VSDropServiceUri>
+        <DropServiceUri>https://devdiv.artifacts.visualstudio.com/</DropServiceUri>
+        <DropExe>$(MSBuildThisDirectory)Tools\Drop.App\lib\net45\Drop.exe</DropExe>
+        <!-- Default drop expiration date is 10 years from now -->
+        <DropExpiration Condition="'$(DropExpiration)' == ''">10</DropExpiration>
+        <DropExpirationDate>$([System.DateTime]::Now.AddYears($(DropExpiration)).ToString("M/d/yyyy h:m:s tt"))</DropExpirationDate>
+        <!-- Timeout in minutes -->
+        <DropTimeout>10</DropTimeout>
+        <!-- Can be set to 'info', 'warn', 'error', 'verbose' -->
+        <DropTraceLevel>verbose</DropTraceLevel>
+
+        <!-- Commandline parameters for drop.exe -->
+        <DropParamService>-s &quot;$(DropServiceUri)&quot;</DropParamService>
+        <DropParamTimeout>--timeout &quot;$(DropTimeout)&quot;</DropParamTimeout>
+        <DropParamTraceLevel>--tracelevel &quot;$(DropTraceLevel)&quot;</DropParamTraceLevel>
+        <DropParamExpirationDate>-x &quot;$(DropExpirationDate)&quot;</DropParamExpirationDate>
+        <!-- Use AAD for authentication -->
+        <DropParamAuth>-a</DropParamAuth>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ManifestTeamProject Condition="'$(ManifestTeamProject)' == ''">dotnet</ManifestTeamProject>
+        <ManifestRepositoryName Condition="'$(ManifestRepositoryName)' == ''">installer</ManifestRepositoryName>
+        <ManifestBuildBranch Condition="'$(ManifestBuildBranch)' == ''">local_build</ManifestBuildBranch>
+        <ManifestBuildNumber Condition="'$(ManifestBuildNumber)' == ''">$([System.DateTime]::Now.ToString("yyMMdd")).1</ManifestBuildNumber>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ManifestPublishUrl>https://vsdrop.corp.microsoft.com/file/v1/Products/$(ManifestTeamProject)/$(ManifestRepositoryName)/$(ManifestBuildBranch)/$(ManifestBuildNumber);</ManifestPublishUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ManifestIntermediateOutputPath>$(OutputPath)\obj\$(MSBuildProject)</ManifestIntermediateOutputPath>
+    </PropertyGroup>
+</Project>

--- a/eng/workloads/VSSetup.targets
+++ b/eng/workloads/VSSetup.targets
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="VSSetup.props" Condition="'$(VSSetupProps)' != '1'"/>
+
+    <Target Name="PublishToVSDrop" DependsOnTargets="GetDropCmdLine">
+        <Exec Command="$(DropUpgradeCmd)" />
+        <Exec Command="$(DropCreateCmd)" />
+        <Exec Command="$(DropPublishCmd)" />
+        <Exec Command="$(DropFinalizeCmd)" />
+        <Exec Command="$(DropUpdateCmd)" />
+
+        <ItemGroup>
+            <DropManifests Include="$(VSDropSource)\*.vsman" />
+        </ItemGroup>
+
+        <WriteLinesToFile File="$(VSDropTxt)" Overwrite="true" Lines="@(DropManifests->'$(ManifestPublishUrl)%(Filename)%(Extension)')" />
+    </Target>
+
+    <Target Name="GetDropCmdLine">
+        <!-- Properties that will depend on each build configuration. We can only build the commandlines onces these are defined -->
+        <Error Text="VSDropSource property undefined" Condition="'$(VSDropSource)' == ''" />
+
+        <PropertyGroup>
+            <DropName>Products/$(ManifestTeamProject)/$(ManifestRepositoryName)/$(ManifestBuildBranch)/$(ManifestBuildNumber)</DropName>
+
+            <DropParamName>-n &quot;$(DropName)&quot;</DropParamName>
+            <DropParamSource>-d &quot;$(VSDropSource)&quot;</DropParamSource>
+
+            <DropUpgradeCmd>$(DropExe) Upgrade $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel)</DropUpgradeCmd>
+            <DropCreateCmd>$(DropExe) Create $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel) $(DropParamExpirationDate) $(DropParamName)</DropCreateCmd>
+            <DropPublishCmd>$(DropExe) Publish $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel) $(DropParamName) $(DropParamSource)</DropPublishCmd>
+            <DropFinalizeCmd>$(DropExe) Finalize $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel) $(DropParamName)</DropFinalizeCmd>
+            <DropUpdateCmd>$(DropExe) Update $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel) $(DropParamName) --neverExpire</DropUpdateCmd>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="VSSetupDiagnostic" DependsOnTargets="GetDropCmdLine">
+        <ItemGroup>
+            <VSSetupProperties Include="Drop cmd: $(DropUpgradeCmd)" />
+            <VSSetupProperties Include="Drop cmd: $(DropCreateCmd)" />
+            <VSSetupProperties Include="Drop cmd: $(DropPublishCmd)" />
+            <VSSetupProperties Include="Drop cmd: $(DropFinalizeCmd)" />
+            <VSSetupProperties Include="Drop cmd: $(DropUpdateCmd)" />
+            <VSSetupProperties Include="DropName: $(DropName)" />
+        </ItemGroup>
+
+        <Message Text="%(VSSetupProperties.Identity)" />
+    </Target>
+</Project>

--- a/eng/workloads/emsdk.vsmanproj
+++ b/eng/workloads/emsdk.vsmanproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="VSSetup.targets" />
+
+  <PropertyGroup>
+    <DebugSymbols>false</DebugSymbols>
+    <IsShippingAssembly>false</IsShippingAssembly>
+    <PublishWindowsPdb>false</PublishWindowsPdb>
+    <TargetType>build-manifest</TargetType>
+    <FinalizeManifest>true</FinalizeManifest>
+    <FinalizeSkipLayout>false</FinalizeSkipLayout>
+    <ProductName>DotNetOptionalWorkloads</ProductName>
+    <ProductFamily>vs</ProductFamily>
+    <ProductFamilyVersion Condition="$(ProductFamilyVersion) == ''">42.42.42</ProductFamilyVersion>
+    <ComputeRelativeUrls>true</ComputeRelativeUrls>
+    <OutputPath>$(ManifestOutputPath)</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MergeManifest Include="$(ManifestOutputPath)\*.json">
+      <RelativeUrl>/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CHS\*.json">
+      <RelativeUrl>/CHS/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CHT\*.json">
+      <RelativeUrl>/CHT/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CSY\*.json">
+      <RelativeUrl>/CSY/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\DEU\*.json">
+      <RelativeUrl>/DEU/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ENU\*.json">
+      <RelativeUrl>/ENU/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ESN\*.json">
+      <RelativeUrl>/ESN/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\FRA\*.json">
+      <RelativeUrl>/FRA/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ITA\*.json">
+      <RelativeUrl>/ITA/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\JPN\*.json">
+      <RelativeUrl>/JPN/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\KOR\*.json">
+      <RelativeUrl>/KOR/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\PLK\*.json">
+      <RelativeUrl>/PLK/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\PTB\*.json">
+      <RelativeUrl>/PTB/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\RUS\*.json">
+      <RelativeUrl>/RUS/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\TRK\*.json">
+      <RelativeUrl>/TRK/</RelativeUrl>
+    </MergeManifest>
+  </ItemGroup>
+
+  <Import Project="$(SwixBuildTargets)"/>
+</Project>

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -1,0 +1,171 @@
+<Project DefaultTargets="Restore;Build">
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <MicrosoftDotNetBuildTasksInstallersTaskTargetFramework>netcoreapp3.1</MicrosoftDotNetBuildTasksInstallersTaskTargetFramework>
+    <MicrosoftDotNetBuildTasksInstallersTaskAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\$(MicrosoftDotNetBuildTasksInstallersTaskTargetFramework)\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
+  </PropertyGroup>
+
+  <UsingTask AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll" TaskName="GenerateVisualStudioWorkload" />
+
+  <UsingTask TaskName="CreateLightCommandPackageDrop" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <WorkloadIntermediateOutputPath>$(ArtifactsObjDir)workloads/</WorkloadIntermediateOutputPath>
+    <WorkloadOutputPath>$(ArtifactsBinDir)workloads/</WorkloadOutputPath>
+    <WorkloadOutputPath Condition="'$(workloadArtifactsPath)' != ''">$(workloadArtifactsPath)/</WorkloadOutputPath>
+    <PackageSource>$(ArtifactsShippingPackagesDir)</PackageSource>
+    <PackageSource Condition="'$(workloadPackagesPath)' != ''">$(workloadPackagesPath)/</PackageSource>
+  </PropertyGroup>
+
+  <!-- Arcade -->
+  <PropertyGroup>
+    <!-- Make the version number not be 42.42.42.42424 -->
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+    <DotNetUseShippingVersion>true</DotNetUseShippingVersion>
+    <!-- Temp directory for light command layouts -->
+    <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
+    <!-- Directory for the zipped up light command package -->
+    <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <WixToolsetPath>$(PkgWix)\tools</WixToolsetPath>
+    <SwixPluginPath>$(PkgMicroBuild_Plugins_SwixBuild_Dotnet)</SwixPluginPath>
+    <SwixBuildTargets>$(SwixPluginPath)\build\MicroBuild.Plugins.SwixBuild.targets</SwixBuildTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Workloads" Version="$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="WiX" Version="$(WixPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="$(SwixPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersPackageVersion)" GeneratePathProperty="True" />
+  </ItemGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <Target Name="Build" DependsOnTargets="GenerateVersions">
+    <ItemGroup>
+      <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
+           these must be updated. -->
+      <ComponentResources Include="microsoft-net-sdk-emscripten" Title=".NET WebAssembly Build Tools (Emscripten)"
+                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
+
+      <!-- Visual Studio components must be versioned. Build tasks will fall back to cobbling a version number from
+           the manifest information unless it's overridden. -->
+      <ComponentVersions Include="microsoft-net-sdk-emscripten" Version="$(AssemblyVersion)" />
+    </ItemGroup>
+
+    <!-- BAR requires having version information in blobs -->
+    <PropertyGroup>
+      <VersionedVisualStudioSetupInsertionPath>$(VisualStudioSetupInsertionPath)$(SDKBundleVersion)\</VersionedVisualStudioSetupInsertionPath>
+    </PropertyGroup>
+
+    <!-- Shorten package names to avoid long path issues in Visual Studio -->
+    <ItemGroup>
+      <ShortNames Include="microsoft.netcore.app.runtime;Microsoft.NETCore.App.Runtime;microsoft.net.runtime;Microsoft.NET.Runtime">
+        <Replacement>Microsoft</Replacement>
+      </ShortNames>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Emscripten.Manifest*.nupkg" />
+    </ItemGroup>
+
+    <GenerateVisualStudioWorkload IntermediateBaseOutputPath="$(WorkloadIntermediateOutputPath)"
+                                  WixToolsetPath="$(WixToolsetPath)"
+                                  GenerateMsis="true"
+                                  ComponentVersions="@(ComponentVersions)"
+                                  OutputPath="$(WorkloadOutputPath)"
+                                  PackagesPath="$(PackageSource)"
+                                  ShortNames="@(ShortNames)"
+                                  WorkloadPackages="@(ManifestPackages)">
+      <Output TaskParameter="SwixProjects" ItemName="SwixProjects" />
+      <Output TaskParameter="Msis" ItemName="Msis" />
+    </GenerateVisualStudioWorkload>
+
+    <!-- Build all the SWIX projects. This requires full framework MSBuild-->
+    <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+
+    <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />
+
+    <!-- Build the Visual Studio manifest project. -->
+    <ItemGroup>
+      <VisualStudioManifestProjects Include="emsdk.vsmanproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(VisualStudioManifestProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath);OutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+
+    <!-- Build all the MSI payload packages for NuGet. -->
+    <ItemGroup>
+      <MsiPackageProjects Include="%(Msis.PackageProject)" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir)" Targets="restore;pack" />
+  </Target>
+
+  <!-- Target to create a single wixpack for signing -->
+  <Target Name="CreateWixPack">
+    <ItemGroup>
+      <_WixObj Include="$(_WixObjDir)\**\*.wixobj" />
+    </ItemGroup>
+
+    <CreateLightCommandPackageDrop
+      LightCommandWorkingDir="$(LightCommandObjDir)"
+      OutputFolder="$(LightCommandPackagesDir)"
+      NoLogo="true"
+      Cultures="en-us"
+      InstallerFile="$(_Msi)"
+      WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
+      WixSrcFiles="@(_WixObj)">
+      <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
+    </CreateLightCommandPackageDrop>
+  </Target>
+
+  <!-- These are just individual targets for testing local builds. -->
+  <Target Name="BuildSwixProjects">
+    <ItemGroup>
+      <SwixProjects Include="$(WorkloadIntermediateOutputPath)**\*.swixproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(SwixProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+  </Target>
+
+  <Target Name="BuildVisualStudioManifest">
+    <ItemGroup>
+      <VisualStudioManifestProjects Include="Microsoft.NET.vsmanproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(VisualStudioManifestProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath);OutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+  </Target>
+
+  <Target Name="GenerateVersions" DependsOnTargets="GetAssemblyVersion">
+    <Exec Command="git rev-list --count HEAD"
+          ConsoleToMSBuild="true"
+          Condition=" '$(GitCommitCount)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
+    </Exec>
+
+    <Error Condition=" '$(OfficialBuild)' == 'true' And '$(_PatchNumber)' == '' "
+           Text="_PatchNumber should not be empty in an official build. Check if there were changes in Arcade." />
+
+    <PropertyGroup>
+      <GitCommitCount>$(GitCommitCount.PadLeft(6,'0'))</GitCommitCount>
+
+      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
+      <CombinedBuildNumberAndRevision>$(_PatchNumber)</CombinedBuildNumberAndRevision>
+      <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
+      <CombinedBuildNumberAndRevision Condition=" '$(CombinedBuildNumberAndRevision)' == '' ">$(GitCommitCount)</CombinedBuildNumberAndRevision>
+
+      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
+      <SDKBundleVersion>$(FileVersion)</SDKBundleVersion>
+      <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
+      <SDKBundleVersion Condition=" '$(SDKBundleVersion)' == '' ">$(VersionPrefix).$(CombinedBuildNumberAndRevision)</SDKBundleVersion>
+    </PropertyGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/emsdk/pull/45 to release/6.0-preview7.

## Customer Impact
Without this PR, customers will not be able to install EMSDK workloads into Visual Studio
## Testing
We validated the packages produced are satisfactory to be inserted into VS.
## Risk
Very low.
