### PR TITLE
[release/6.0-preview7] Fixup blob paths interim

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -4,6 +4,7 @@
       <PublishingVersion>3</PublishingVersion>
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages> <!-- we don't need symbol packages for emsdk -->
       <PostBuildSign>true</PostBuildSign>
+      <_UploadPathRoot>emsdk</_UploadPathRoot>
    </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +20,7 @@
       <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
         <IsShipping>true</IsShipping>
         <PublishFlatContainer>true</PublishFlatContainer>
-        <RelativeBlobPath>$(_UploadPathRoot)/%(_InstallersToPublish.UploadPathSegment)/$(_PackageVersion)/%(Filename)%(Extension)</RelativeBlobPath>
+        <RelativeBlobPath>$(_UploadPathRoot)/%(_InstallersToPublish.UploadPathSegment)/%(Filename)%(Extension)</RelativeBlobPath>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Temporary fix for the blob path issues for the wixpacks. Previously the missing _UploadPathRoot was causing paths like:
`/wixpack//foofile.6.0.0-preview.1234.wixpack.zip`
This causes problems in gather drop due to Path.Combine behavior (the rooted path wins and the file is placed in the root of the directory structure).
This is not a full solution, because when stable builds happen, these paths must be unique. At that point, the `foofile.6.0.0-preview.1234.wixpack.zip` will end up foofile.6.0.0.wixpack.zip, which
will be non-unique in blob storage.
Fixing this requires a bit of messing about to get full version info in the publishing targets, so deferring that for now and unblocking signing.