### PR TITLE
Add the dummy non shipping project to calculate the package version

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <Target Name="_PublishInstallers">
-    <MSBuild Projects="$(RepoRoot)eng\nuget\Microsoft.NET.Runtime.Emscripten.Sdk\Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj"
+    <MSBuild Projects="$(RepoRoot)eng\nuget\Microsoft.NET.Dummy\Microsoft.NET.Dummy.pkgproj"
         Properties="DisableYarnCheck=true;ExcludeFromBuild=false"
         Targets="GetPackageIdentity"
         SkipNonexistentProjects="false">

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -148,6 +148,7 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Python\Microsoft.NET.Runtime.Emscripten.Python.pkgproj" Targets="Build" Condition="'$(UsesPythonFromEmsdk)' == 'true'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk\Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj" Targets="Build" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Manifest\Microsoft.NET.Workload.Emscripten.Manifest.pkgproj" Targets="Build" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'win'" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Dummy\Microsoft.NET.Dummy.pkgproj" Targets="Build" Condition="'$(OS)' == 'Windows_NT'" />
   </Target>
   <Import Project="$(RepoRoot)\Directory.Build.targets" />
 </Project>

--- a/eng/nuget/Microsoft.NET.Dummy/Microsoft.NET.Dummy.pkgproj
+++ b/eng/nuget/Microsoft.NET.Dummy/Microsoft.NET.Dummy.pkgproj
@@ -1,0 +1,16 @@
+<Project>
+  <Import Project="$(RepoRoot)\Directory.Build.props" />
+  <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Microsoft.NET.Runtime.Emscripten.Common.props))" />
+
+  <PropertyGroup>
+    <PackageDescription>Dummy Package</PackageDescription>
+    <Description>Dummy Package</Description>
+    <IsShipping>false</IsShipping>
+    <VersionSuffix>$(_PreReleaseLabel)$(_BuildNumberLabels)</VersionSuffix>
+    <StableVersion></StableVersion>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />
+  <Import Project="..\Directory.Build.targets" />
+</Project>


### PR DESCRIPTION
This change add the version suffix to the published blob paths. this is needed to have unique paths for all the multiple builds publishing the same package version to the storage account.