### PR TITLE
Tweak workload build to use _GenerateMsiVersionString target

### DIFF
--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -50,14 +50,7 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Target Name="Build">
-    <PropertyGroup>
-      <_MajorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Major)</_MajorVersion>
-      <_MinorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Minor)</_MinorVersion>
-      <_PatchVersion>$([System.Version]::Parse('$(AssemblyVersion)').Build)</_PatchVersion>
-      <_BuildNumber>$([System.Version]::Parse('$(AssemblyVersion)').Revision)</_BuildNumber>
-    </PropertyGroup>
-
+  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
@@ -84,30 +77,6 @@
     <ItemGroup>
       <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Emscripten.Manifest*.nupkg" />
     </ItemGroup>
-
-    <PropertyGroup>
-      <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
-      <!-- Using the following default comparison date will produce versions that align with our internal build system. -->
-      <VersionComparisonDate Condition="'$(VersionComparisonDate)'==''">1996-04-01</VersionComparisonDate>
-    </PropertyGroup>
-
-    <GenerateCurrentVersion
-      SeedDate="$([System.DateTime]::Now.ToString(yyyy-MM-dd))"
-      OfficialBuildId="$(OfficialBuildId)"
-      ComparisonDate="$(VersionComparisonDate)"
-      Padding="$(VersionPadding)">
-      <Output PropertyName="BuildNumberMajor" TaskParameter="GeneratedVersion" />
-      <Output PropertyName="BuildNumberMinor" TaskParameter="GeneratedRevision" />
-    </GenerateCurrentVersion>
-
-    <GenerateMsiVersion
-      Major="$(_MajorVersion)"
-      Minor="$(_MinorVersion)"
-      Patch="$(_PatchVersion)"
-      BuildNumberMajor="$(BuildNumberMajor)"
-      BuildNumberMinor="$(BuildNumberMinor)">
-      <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />
-    </GenerateMsiVersion>
 
     <GenerateManifestMsi
         IntermediateBaseOutputPath="$(IntermediateOutputPath)"
@@ -187,5 +156,40 @@
     </ItemGroup>
 
     <MSBuild Projects="@(VisualStudioManifestProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath);OutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+  </Target>
+
+  <Target Name="_GetVersionProps">
+    <PropertyGroup>
+      <_MajorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Major)</_MajorVersion>
+      <_MinorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Minor)</_MinorVersion>
+      <_PatchVersion>$([System.Version]::Parse('$(AssemblyVersion)').Build)</_PatchVersion>
+      <_BuildNumber>$([System.Version]::Parse('$(AssemblyVersion)').Revision)</_BuildNumber>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_GenerateMsiVersionString">
+    <PropertyGroup>
+      <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
+      <!-- Using the following default comparison date will produce versions that align with our internal build system. -->
+      <VersionComparisonDate Condition="'$(VersionComparisonDate)'==''">1996-04-01</VersionComparisonDate>
+    </PropertyGroup>
+
+    <GenerateCurrentVersion
+      SeedDate="$([System.DateTime]::Now.ToString(yyyy-MM-dd))"
+      OfficialBuildId="$(OfficialBuildId)"
+      ComparisonDate="$(VersionComparisonDate)"
+      Padding="$(VersionPadding)">
+      <Output PropertyName="BuildNumberMajor" TaskParameter="GeneratedVersion" />
+      <Output PropertyName="BuildNumberMinor" TaskParameter="GeneratedRevision" />
+    </GenerateCurrentVersion>
+
+    <GenerateMsiVersion
+      Major="$(_MajorVersion)"
+      Minor="$(_MinorVersion)"
+      Patch="$(_PatchVersion)"
+      BuildNumberMajor="$(BuildNumberMajor)"
+      BuildNumberMinor="$(BuildNumberMinor)">
+      <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />
+    </GenerateMsiVersion>
   </Target>
 </Project>


### PR DESCRIPTION
Replaces GenerateVersions that wasn't quite accurate enough for what we need