### PR TITLE
[release/6.0] Tweak workload build to use _GenerateMsiVersionString target

### DIFF
--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <MicrosoftDotNetBuildTasksInstallersTaskTargetFramework>netcoreapp3.1</MicrosoftDotNetBuildTasksInstallersTaskTargetFramework>
-    <MicrosoftDotNetBuildTasksInstallersTaskAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\$(MicrosoftDotNetBuildTasksInstallersTaskTargetFramework)\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
+    <MicrosoftDotNetBuildTasksInstallersPath>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)</MicrosoftDotNetBuildTasksInstallersPath>
+    <MicrosoftDotNetBuildTasksInstallersTaskAssembly>$(MicrosoftDotNetBuildTasksInstallersPath)\tools\$(MicrosoftDotNetBuildTasksInstallersTaskTargetFramework)\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll" TaskName="GenerateManifestMsi" />
@@ -49,7 +50,7 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Target Name="Build" DependsOnTargets="GenerateVersions">
+  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
@@ -76,14 +77,6 @@
     <ItemGroup>
       <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Emscripten.Manifest*.nupkg" />
     </ItemGroup>
-
-    <GenerateMsiVersion
-        Major="$([System.Version]::Parse('$(AssemblyVersion)').Major)"
-        Minor="$([System.Version]::Parse('$(AssemblyVersion)').Minor)"
-        Patch="$([System.Version]::Parse('$(AssemblyVersion)').Build)"
-        BuildNumber="$([System.Version]::Parse('$(AssemblyVersion)').Revision)" >
-      <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />
-    </GenerateMsiVersion>
 
     <GenerateManifestMsi
         IntermediateBaseOutputPath="$(IntermediateOutputPath)"
@@ -165,28 +158,38 @@
     <MSBuild Projects="@(VisualStudioManifestProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath);OutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
   </Target>
 
-  <Target Name="GenerateVersions" DependsOnTargets="GetAssemblyVersion">
-    <Exec Command="git rev-list --count HEAD"
-          ConsoleToMSBuild="true"
-          Condition=" '$(GitCommitCount)' == '' ">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
-    </Exec>
-
-    <Error Condition=" '$(OfficialBuild)' == 'true' And '$(_PatchNumber)' == '' "
-           Text="_PatchNumber should not be empty in an official build. Check if there were changes in Arcade." />
-
+  <Target Name="_GetVersionProps">
     <PropertyGroup>
-      <GitCommitCount>$(GitCommitCount.PadLeft(6,'0'))</GitCommitCount>
-
-      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
-      <CombinedBuildNumberAndRevision>$(_PatchNumber)</CombinedBuildNumberAndRevision>
-      <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
-      <CombinedBuildNumberAndRevision Condition=" '$(CombinedBuildNumberAndRevision)' == '' ">$(GitCommitCount)</CombinedBuildNumberAndRevision>
-
-      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
-      <SDKBundleVersion>$(FileVersion)</SDKBundleVersion>
-      <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
-      <SDKBundleVersion Condition=" '$(SDKBundleVersion)' == '' ">$(VersionPrefix).$(CombinedBuildNumberAndRevision)</SDKBundleVersion>
+      <_MajorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Major)</_MajorVersion>
+      <_MinorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Minor)</_MinorVersion>
+      <_PatchVersion>$([System.Version]::Parse('$(AssemblyVersion)').Build)</_PatchVersion>
+      <_BuildNumber>$([System.Version]::Parse('$(AssemblyVersion)').Revision)</_BuildNumber>
     </PropertyGroup>
+  </Target>
+
+  <Target Name="_GenerateMsiVersionString">
+    <PropertyGroup>
+      <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
+      <!-- Using the following default comparison date will produce versions that align with our internal build system. -->
+      <VersionComparisonDate Condition="'$(VersionComparisonDate)'==''">1996-04-01</VersionComparisonDate>
+    </PropertyGroup>
+
+    <GenerateCurrentVersion
+      SeedDate="$([System.DateTime]::Now.ToString(yyyy-MM-dd))"
+      OfficialBuildId="$(OfficialBuildId)"
+      ComparisonDate="$(VersionComparisonDate)"
+      Padding="$(VersionPadding)">
+      <Output PropertyName="BuildNumberMajor" TaskParameter="GeneratedVersion" />
+      <Output PropertyName="BuildNumberMinor" TaskParameter="GeneratedRevision" />
+    </GenerateCurrentVersion>
+
+    <GenerateMsiVersion
+      Major="$(_MajorVersion)"
+      Minor="$(_MinorVersion)"
+      Patch="$(_PatchVersion)"
+      BuildNumberMajor="$(BuildNumberMajor)"
+      BuildNumberMinor="$(BuildNumberMinor)">
+      <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />
+    </GenerateMsiVersion>
   </Target>
 </Project>


### PR DESCRIPTION
backport of https://github.com/dotnet/emsdk/pull/87

* Tweak workload build to use _GenerateMsiVersionString target

Replaces GenerateVersions that wasn't quite accurate enough for what we need

* Import wix targets directly

* Copy in the arcade task - will remmove later

* More tweaks

* Make sure things happen in build target

* Forgot a depends target

Co-authored-by: Steve Pfister <steve.pfister@microsoft.com>