### PR TITLE
[release/6.0-maui] Bump sdk band in Emscripten workload identifier

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <EmscriptenVersion>2.0.23</EmscriptenVersion>
-    <WorkloadSdkBandVersion>6.0.100</WorkloadSdkBandVersion>
+    <WorkloadSdkBandVersion>6.0.200</WorkloadSdkBandVersion>
   </PropertyGroup>
   <PropertyGroup>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>


### PR DESCRIPTION
In order to avoid issues with the dotnet sdk not being able to roll back previous band workloads, bump the emscripten workload to have a 200 band id.  There are no changes within the workload itself.