### PR TITLE
Publish manifests for 6.0.100 and 6.0.200 sdks

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
     <EmscriptenVersion>2.0.23</EmscriptenVersion>
-    <WorkloadSdkBandVersion>6.0.100</WorkloadSdkBandVersion>
+    <WorkloadSdkBandVersion Condition="'$(WorkloadSdkBandVersion)' == ''">6.0.100</WorkloadSdkBandVersion>
   </PropertyGroup>
   <ItemGroup>
     <WorkloadSdkBandVersions Include="6.0.100;6.0.200" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,6 +8,9 @@
     <EmscriptenVersion>2.0.23</EmscriptenVersion>
     <WorkloadSdkBandVersion>6.0.100</WorkloadSdkBandVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <WorkloadSdkBandVersions Include="6.0.100;6.0.200" />
+  </ItemGroup>
   <PropertyGroup>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -147,7 +147,7 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Node\Microsoft.NET.Runtime.Emscripten.Node.pkgproj" Targets="Build" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Python\Microsoft.NET.Runtime.Emscripten.Python.pkgproj" Targets="Build" Condition="'$(UsesPythonFromEmsdk)' == 'true'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk\Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj" Targets="Build" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Manifest\Microsoft.NET.Workload.Emscripten.Manifest.pkgproj" Targets="Build" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'win'" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Manifest\Microsoft.NET.Workload.Emscripten.Manifest.pkgproj" Targets="Build" Properties="WorkloadSdkBandVersion=%(WorkloadSdkBandVersions)" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'win'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk.Internal\Microsoft.NET.Runtime.Emscripten.Sdk.Internal.pkgproj" Targets="Build" Condition="'$(OS)' == 'Windows_NT'" />
   </Target>
   <Import Project="$(RepoRoot)\Directory.Build.targets" />

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -147,8 +147,8 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Node\Microsoft.NET.Runtime.Emscripten.Node.pkgproj" Targets="Build" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Python\Microsoft.NET.Runtime.Emscripten.Python.pkgproj" Targets="Build" Condition="'$(UsesPythonFromEmsdk)' == 'true'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk\Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj" Targets="Build" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Manifest\Microsoft.NET.Workload.Emscripten.Manifest.pkgproj" Targets="Build" Properties="WorkloadSdkBandVersion=%(WorkloadSdkBandVersions)" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'win'" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk.Internal\Microsoft.NET.Runtime.Emscripten.Sdk.Internal.pkgproj" Targets="Build" Condition="'$(OS)' == 'Windows_NT'" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Manifest\Microsoft.NET.Workload.Emscripten.Manifest.pkgproj" Targets="Build" Properties="WorkloadSdkBandVersion=%(WorkloadSdkBandVersions.Identity)" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'win'" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk.Internal\Microsoft.NET.Runtime.Emscripten.Sdk.Internal.pkgproj" Targets="Build" Properties="WorkloadSdkBandVersion=%(WorkloadSdkBandVersions)" Condition="'$(OS)' == 'Windows_NT'" />
   </Target>
   <Import Project="$(RepoRoot)\Directory.Build.targets" />
 </Project>


### PR DESCRIPTION
Addresses an issue where a newer (200) sdk cannot rollback 6.0.100 manifests