### PR TITLE
Remove unused tools on windows

### DIFF
--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -103,6 +103,8 @@
     <Delete Files="$(ArtifactsObjDir)upstream\bin\wasm32-wasi-clang++.exe" />
     <Delete Files="$(ArtifactsObjDir)upstream\bin\ld64.lld.darwinnew.exe" />
     <Delete Files="$(ArtifactsObjDir)upstream\bin\ld64.lld.exe" />
+    <Delete Files="$(ArtifactsObjDir)upstream\bin\clang-repl.exe" />
+    <Delete Files="$(ArtifactsObjDir)upstream\bin\llvm-ml.exe" />
     <Delete Files="$(ArtifactsObjDir)upstream\emscripten\third_party\*.*" />
     <!--<Delete Files="$(ArtifactsObjDir)upstream\bin\wasm-ld.exe" />--> <!-- TODO: this is used by emcc but could be a symlink to ld.exe -->
 


### PR DESCRIPTION
These 2 tools were added with the emscripten 2.0.34 and increase the nuget
size a lot.

    +  70,630,912 tools/bin/clang-repl.exe *2
    +   8,182,272 tools/bin/llvm-ml.exe *2

They are not present in the emscripten 3.1.1, so I think it should be
fine to remove them.