### PR TITLE
[release/7.0-preview2] Go back to emscripten 2.0.23

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <WorkloadSdkBandVersion>7.0.100</WorkloadSdkBandVersion>
-    <EmscriptenVersion>2.0.34</EmscriptenVersion>
+    <EmscriptenVersion>2.0.23</EmscriptenVersion>
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftDotNetBuildTasksPackagingVersion>7.0.0-beta.22111.10</MicrosoftDotNetBuildTasksPackagingVersion>


### PR DESCRIPTION
To allow rollback of emscripten in dotnet/runtime 7.0-preview2 branch