### PR TITLE
Revert "Add emulated win-arm64 packs"

### DIFF
--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.Manifest/WorkloadManifest.json.in
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.Manifest/WorkloadManifest.json.in
@@ -9,7 +9,7 @@
         "Microsoft.NET.Runtime.Emscripten.Python",
         "Microsoft.NET.Runtime.Emscripten.Sdk"
       ],
-      "platforms": [ "win-x64", "win-arm64", "linux-x64", "osx-x64", "osx-arm64" ]
+      "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
     }
   },
   "packs": {
@@ -18,7 +18,6 @@
       "version": "${PackageVersion}",
       "alias-to": {
         "win-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.win-x64",
-        "win-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.win-x64",
         "linux-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.linux-x64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.osx-x64",
         "osx-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.osx-x64"
@@ -29,7 +28,6 @@
       "version": "${PackageVersion}",
       "alias-to": {
         "win-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Python.win-x64",
-        "win-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Python.win-x64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Python.osx-x64",
         "osx-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Python.osx-x64"
       }
@@ -39,7 +37,6 @@
       "version": "${PackageVersion}",
       "alias-to": {
         "win-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.win-x64",
-        "win-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.win-x64",
         "linux-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.linux-x64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.osx-x64",
         "osx-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.osx-x64"


### PR DESCRIPTION
Reverts dotnet/emsdk#109

Rolling this back because it appears to be racy in the workload processing step with the same assets