### PR TITLE
Add support for in-build signing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -3,7 +3,6 @@
    <PropertyGroup>
       <PublishingVersion>3</PublishingVersion>
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages> <!-- we don't need symbol packages for emsdk -->
-      <PostBuildSign>true</PostBuildSign>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -8,7 +8,7 @@
     <FileExtensionSignInfo Update=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Update=".zip" CertificateName="None" />
     <FileExtensionSignInfo Include=".cat" CertificateName="3PartySHA2" />
-    <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pyd" CertificateName="3PartySHA2" />
 
     <!--
@@ -21,6 +21,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ItemsToSignPostBuild Include="$(VisualStudioSetupInsertionPath)\**\*.msi" />
+    <ItemsToSign Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />
+    <ItemsToSignPostBuild Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -101,13 +101,13 @@ stages:
               path: 'artifacts/packages'
 
           - powershell: |
-              ./eng/common/build.ps1 -ci -configuration -restore -sign -publish $(_BuildConfig) /p:PackageRID=linux-x64 /p:AssetManifestOS=linux /p:PlatformName=x64 $(_InternalBuildArgs)
+              ./eng/common/build.ps1 -ci -configuration $(_BuildConfig) -restore -sign -publish /p:PackageRID=linux-x64 /p:AssetManifestOS=linux /p:PlatformName=x64 $(_InternalBuildArgs)
             displayName: Sign and Publish
 
       ############ Windows BUILD ############
       - job: Build_Windows
         displayName: Windows
-        timeoutInMinutes: 30
+        timeoutInMinutes: 60
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             vmImage: windows-2019

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -37,13 +37,32 @@ stages:
           vmImage: macOS-10.15
         steps:
         - bash: |
-            ./build.sh -ci -configuration $(_BuildConfig) $(_InternalPublishArg) /p:PackageRID=osx-x64 /p:AssetManifestOS=osx /p:PlatformName=x64 $(_InternalBuildArgs)
-          displayName: Build and Publish
+            ./build.sh -ci -configuration $(_BuildConfig) /p:PackageRID=osx-x64 /p:AssetManifestOS=osx /p:PlatformName=x64 $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+          displayName: Build
         - publish: artifacts/packages
           artifact: Packages_macOS
         - bash: |
             rm -rf upstream node python
           displayName: Remove temporary artifacts
+
+      # Only run in case of in-build signing
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+        - job: Sign_macOS
+          dependsOn: Build_macOS
+          displayName: Sign macOS
+          timeoutInMinutes: 30
+          pool:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          steps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: Packages_macOS
+              path: 'artifacts/packages'
+
+          - powershell: |
+              ./eng/common/build.ps1 -ci -configuration $(_BuildConfig) -restore -sign -publish /p:PackageRID=osx-x64 /p:AssetManifestOS=osx /p:PlatformName=x64 $(_InternalBuildArgs)
+            displayName: Sign and Publish
 
       ############ Linux BUILD ############
       - job: Build_Linux
@@ -57,13 +76,32 @@ stages:
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
         steps:
         - bash: |
-            ./build.sh -ci -configuration $(_BuildConfig) $(_InternalPublishArg) /p:PackageRID=linux-x64 /p:AssetManifestOS=linux /p:PlatformName=x64 $(_InternalBuildArgs)
-          displayName: Build and Publish
+            ./build.sh -ci -configuration $(_BuildConfig) /p:PackageRID=linux-x64 /p:AssetManifestOS=linux /p:PlatformName=x64 $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+          displayName: Build
         - publish: artifacts/packages
           artifact: Packages_Linux
         - bash: |
             rm -rf upstream node python
           displayName: Remove temporary artifacts
+
+      # Only run in case of in-build signing
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+        - job: Sign_Linux
+          dependsOn: Build_Linux
+          displayName: Sign Linux
+          timeoutInMinutes: 30
+          pool:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          steps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: Packages_Linux
+              path: 'artifacts/packages'
+
+          - powershell: |
+              ./eng/common/build.ps1 -ci -configuration -restore -sign -publish $(_BuildConfig) /p:PackageRID=linux-x64 /p:AssetManifestOS=linux /p:PlatformName=x64 $(_InternalBuildArgs)
+            displayName: Sign and Publish
 
       ############ Windows BUILD ############
       - job: Build_Windows
@@ -105,7 +143,7 @@ stages:
           displayName: Fetch storage.googleapis.com certificate
           condition: eq(variables['System.TeamProject'], 'internal')
         - script: |
-            .\build.cmd -ci -configuration $(_BuildConfig) $(_InternalPublishArg) /p:PackageRID=win-x64 /p:AssetManifestOS=win /p:PlatformName=x64 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping $(_InternalBuildArgs)
+            .\build.cmd -ci -configuration $(_BuildConfig) -sign -publish /p:PackageRID=win-x64 /p:AssetManifestOS=win /p:PlatformName=x64 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping $(_InternalBuildArgs)
           displayName: Build and Publish
         - publish: artifacts/packages
           artifact: Packages_Windows

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -25,6 +25,7 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
       enablePublishUsingPipelines: true
+      enableMicrobuild: true
       variables:
         - _BuildConfig: Release
       jobs:

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -12,7 +12,13 @@ variables:
     value: ''
   - name: _InternalPublishArg
     value: ''
+  - name: PostBuildSign
+    value: true
 
+  # If post build signing, then OSX and Linux don't publish during their main pass. Otherwise, always publish
+  - ${{ if eq(variables['PostBuildSign'], 'true') }}:
+    - name: _NonWindowsInternalPublishArg
+      value: -publish
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _RunAsPublic
       value: False
@@ -25,8 +31,6 @@ variables:
     - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
-    - name: _InternalPublishArg
-      value: -publish
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) 
         /p:TeamName=$(_TeamName)


### PR DESCRIPTION
- Add an explicit flag for post-build signing
- In-build signing is only supported on Windows. This repo creates some packages on Mac and Linux, and at the moment they can only be created on those platforms. When post build signing isn't enabled, download the artifacts for those platforms and run the sign and publish phases of the build.
- Update the cert for the MSIs to be the .NET Cert
- Move the PostBuildSIgn flag into the YAML so it can be used in template expressions
- Pass -sign (harmless if post-build sign is on) in all ci cases.
- Always publish even on PRs, there's no harm in it.