### PR TITLE
Fix publishing for non-windows platforms

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -16,7 +16,7 @@ variables:
     value: true
 
   # If post build signing, then OSX and Linux don't publish during their main pass. Otherwise, always publish
-  - ${{ if eq(variables['PostBuildSign'], 'true') }}:
+  - $[ if eq(variables.PostBuildSign, 'true') ]:
     - name: _NonWindowsInternalPublishArg
       value: -publish
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -17,7 +17,7 @@ variables:
 
   # If post build signing, then OSX and Linux don't publish during their main pass. Otherwise, always publish
   - name: _NonWindowsInternalPublishArg
-    $[ if eq(variables['PostBuildSign'], 'true') ]:
+    ${{ if eq(variables['PostBuildSign'], 'true') }}:
       value: -publish
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _RunAsPublic

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -16,8 +16,8 @@ variables:
     value: true
 
   # If post build signing, then OSX and Linux don't publish during their main pass. Otherwise, always publish
-  - $[ if eq(variables.PostBuildSign, 'true') ]:
-    - name: _NonWindowsInternalPublishArg
+  - name: _NonWindowsInternalPublishArg
+    $[ if eq(variables.PostBuildSign, 'true') ]:
       value: -publish
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _RunAsPublic

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -17,7 +17,7 @@ variables:
 
   # If post build signing, then OSX and Linux don't publish during their main pass. Otherwise, always publish
   - name: _NonWindowsInternalPublishArg
-    $[ if eq(variables.PostBuildSign, 'true') ]:
+    $[ if eq(variables['PostBuildSign'], 'true') ]:
       value: -publish
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _RunAsPublic


### PR DESCRIPTION
In the PR https://github.com/dotnet/emsdk/pull/164 a new variable was added conditionally:

```yml
   # If post build signing, then OSX and Linux don't publish during their main pass. Otherwise, always publish
   - ${{ if eq(variables['PostBuildSign'], 'true') }}:
     - name: _NonWindowsInternalPublishArg
       value: -publish
```

.. but this resulted in the variable not getting defined at all in the final yaml.
We need to move the if to the variable _value_ instead.

FYI @mmitche 