### PR TITLE
[release/7.0-rc1] Rollback 6.0.x

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <WorkloadSdkBandVersion>7.0.100</WorkloadSdkBandVersion>
     <EmscriptenVersion>3.1.12</EmscriptenVersion>
     <EmscriptenVersionNet6>2.0.23</EmscriptenVersionNet6>
-    <PackageVersionNet6>6.0.9</PackageVersionNet6>
+    <PackageVersionNet6>6.0.8</PackageVersionNet6>
   </PropertyGroup>
   <PropertyGroup>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>


### PR DESCRIPTION
These packages are in dotnet-public is there any reason not to reference them while we sort this out?