### PR TITLE
[release/7.0-rc1] make a 6.0.4 build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <WorkloadSdkBandVersion>7.0.100</WorkloadSdkBandVersion>
     <EmscriptenVersion>3.1.12</EmscriptenVersion>
     <EmscriptenVersionNet6>2.0.23</EmscriptenVersionNet6>
-    <PackageVersionNet6>6.0.9</PackageVersionNet6>
+    <PackageVersionNet6>6.0.4</PackageVersionNet6>
   </PropertyGroup>
   <PropertyGroup>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>


### PR DESCRIPTION
mea culpa on not checking the feeds for 6.0.8, I forgot we hadn't really published those packages even internally

because I would really like to see a runtime build working with these packages I think it is worth landing this for another build cycle, the alternative is pushing 6.0.8 packs to a feed runtime can use.