### PR TITLE
[release/7.0-rc1] Do not attempt to sign .cat files

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -7,7 +7,6 @@
     <FileExtensionSignInfo Update="@(FileExtensionSignInfo)" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Update=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Update=".zip" CertificateName="None" />
-    <FileExtensionSignInfo Include=".cat" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pyd" CertificateName="3PartySHA2" />
 


### PR DESCRIPTION
.cat files cannot be dual signed. However, there was a bug in signtool.exe where an attempt to add a second signature did not fail, and instead corrupted the cat file. Validation steps were added in the signing process to avoid this situation, and this broke builds.