### PR TITLE
Do not attempt to sign .cat files (#190)

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -7,8 +7,7 @@
     <FileExtensionSignInfo Update="@(FileExtensionSignInfo)" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Update=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Update=".zip" CertificateName="None" />
-    <FileExtensionSignInfo Include=".cat" CertificateName="3PartySHA2" />
-    <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pyd" CertificateName="3PartySHA2" />
 
     <!--

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -17,6 +17,9 @@
     <FileExtensionSignInfo Update=".ps1" CertificateName="None" />
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
     <FileExtensionSignInfo Include=".vbs" CertificateName="None" />
+
+    <!-- python.cat is already signed and cannot be re-signed -->
+    <FileSignInfo Include="python.cat" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
.cat files cannot be dual signed. However, there was a bug in signtool.exe where an attempt to add a second signature did not fail, and instead corrupted the cat file. Validation steps were added in the signing process to avoid this situation, and this broke builds.

Also fix the msi signing cert to be .NET's