### PR TITLE
Explicitly avoid signing python.cat

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -17,6 +17,9 @@
     <FileExtensionSignInfo Update=".ps1" CertificateName="None" />
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
     <FileExtensionSignInfo Include=".vbs" CertificateName="None" />
+
+    <!-- python.cat is already signed and cannot be re-signed -->
+    <FileSignInfo Include="python.cat" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Set the python.cat signature to None so that tooling doesn't complain about not having a signature mapping for this file.