### PR TITLE
[release/7.0] sync rc1

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -7,7 +7,6 @@
     <FileExtensionSignInfo Update="@(FileExtensionSignInfo)" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Update=".nupkg" CertificateName="NuGet" />
     <FileExtensionSignInfo Update=".zip" CertificateName="None" />
-    <FileExtensionSignInfo Include=".cat" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pyd" CertificateName="3PartySHA2" />
 
@@ -18,6 +17,9 @@
     <FileExtensionSignInfo Update=".ps1" CertificateName="None" />
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
     <FileExtensionSignInfo Include=".vbs" CertificateName="None" />
+
+    <!-- python.cat is already signed and cannot be re-signed -->
+    <FileSignInfo Include="python.cat" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
commit 5ef661392ae7b1595b683df83d63e3a0365fc126
Author: Matt Mitchell <mmitche@microsoft.com>
Date:   Wed Aug 24 09:22:40 2022 -0700

    Explicitly avoid signing python.cat (#192)

    Set the python.cat signature to None so that tooling doesn't complain about not having a signature mapping for this file.

commit 321399ab3ab4853fbf861b2eaed2113447a6d7e4
Author: Matt Mitchell <mmitche@microsoft.com>
Date:   Tue Aug 23 11:51:37 2022 -0700

    Do not attempt to sign .cat files (#190)

    .cat files cannot be dual signed. However, there was a bug in signtool.exe where an attempt to add a second signature did not fail, and instead corrupted the cat file. Validation steps were added in the signing process to avoid this situation, and this broke builds.