### PR TITLE
[release/6.0] Stop publishing 6.0.200 sdk band and bump release version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>6.0.9</VersionPrefix>
+    <VersionPrefix>6.0.10</VersionPrefix>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>
@@ -9,7 +9,7 @@
     <WorkloadSdkBandVersion Condition="'$(WorkloadSdkBandVersion)' == ''">6.0.100</WorkloadSdkBandVersion>
   </PropertyGroup>
   <ItemGroup>
-    <WorkloadSdkBandVersions Include="6.0.100;6.0.200;6.0.300;6.0.400" />
+    <WorkloadSdkBandVersions Include="6.0.100;6.0.300;6.0.400" />
   </ItemGroup>
   <PropertyGroup>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>


### PR DESCRIPTION
staging this for october, if it needs to go in sooner remove the version bump