### PR TITLE
[main] [wasm-mt] Create a Microsoft.NET.Runtime.Emscripten.Cache

### DIFF
--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -124,29 +124,42 @@
     <Delete Files="$(ArtifactsObjDir)upstream\emscripten\third_party\*.*" />
     <!--<Delete Files="$(ArtifactsObjDir)upstream\bin\wasm-ld.exe" />--> <!-- TODO: this is used by emcc but could be a symlink to ld.exe -->
 
+    <PropertyGroup>
+      <CacheSdkFilesDir>$(ArtifactsObjDir)\.cache-sdk\</CacheSdkFilesDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <CacheSdkFilesToMove Include="$(ArtifactsObjDir)upstream\emscripten\cache\**\*" />
+    </ItemGroup>
+
+    <!-- move the emscripten cache to a separate directory -->
+    <Move SourceFiles="@(CacheSdkFilesToMove)"
+          DestinationFiles="$(CacheSdkFilesDir)emscripten\cache\%(RecursiveDir)%(Filename)%(Extension)" />
+
     <ItemGroup>
       <!-- delete these libs from the cache to reduce windows nuget size context: https://github.com/dotnet/emsdk/pull/34#issuecomment-872691739 -->
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_js.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_rt-mt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_rt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libc_rt_wasm-asan-optz.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libc_rt_wasm-asan.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libc-asan.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libc-mt-asan.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_common_rt-mt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_common_rt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_rt-mt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_rt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libprintf_long_double-asan.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libprintf_long_double-mt-asan.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libsanitizer_common_rt-mt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libsanitizer_common_rt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_minimal_rt_wasm-mt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_minimal_rt_wasm.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt-mt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\lib*-mt.a" />
-      <DeleteCacheFiles Include="$(ArtifactsObjDir)upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\lib*-mt-*.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_js.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_rt-mt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libasan_rt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libc_rt_wasm-asan-optz.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libc_rt_wasm-asan.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libc-asan.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libc-mt-asan.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_common_rt-mt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_common_rt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_rt-mt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\liblsan_rt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libprintf_long_double-asan.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libprintf_long_double-mt-asan.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libsanitizer_common_rt-mt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libsanitizer_common_rt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_minimal_rt_wasm-mt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_minimal_rt_wasm.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt-mt.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\libubsan_rt.a" />
+      <!-- delete the non-pthreads Emscripten WebWorker API libs -->
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\lib*-ww.a" />
+      <DeleteCacheFiles Include="$(CacheSdkFilesDir)emscripten\cache\sysroot\lib\wasm32-emscripten\lib*-ww-*.a" />
     </ItemGroup>
     <Delete Files="@(DeleteCacheFiles)" />
 
@@ -165,6 +178,7 @@
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Node\Microsoft.NET.Runtime.Emscripten.Node.pkgproj" Targets="Build" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Python\Microsoft.NET.Runtime.Emscripten.Python.pkgproj" Targets="Build" Condition="'$(UsesPythonFromEmsdk)' == 'true'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk\Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj" Targets="Build" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Cache\Microsoft.NET.Runtime.Emscripten.Cache.pkgproj" Targets="Build" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.net6.Manifest\Microsoft.NET.Workload.Emscripten.net6.Manifest.pkgproj" Targets="Build" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'win'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.net7.Manifest\Microsoft.NET.Workload.Emscripten.net7.Manifest.pkgproj" Targets="Build" Condition="'$(AssetManifestOS)' == '' or '$(AssetManifestOS)' == 'win'" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk.Internal\Microsoft.NET.Runtime.Emscripten.Sdk.Internal.pkgproj" Targets="Build" Condition="'$(OS)' == 'Windows_NT'" />

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Cache/Microsoft.NET.Runtime.Emscripten.Cache.pkgproj
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Cache/Microsoft.NET.Runtime.Emscripten.Cache.pkgproj
@@ -1,0 +1,21 @@
+<Project>
+  <Import Project="$(RepoRoot)\Directory.Build.props" />
+  <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Microsoft.NET.Runtime.Emscripten.Common.props))" />
+  <Import Project="Microsoft.NET.Runtime.Emscripten.Cache.props" />
+
+  <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" DependsOnTargets="GenerateUnixPermissionsFile" Returns="@(PackageFile)">
+    <!-- Override the id to include the Emscripten version -->
+    <PropertyGroup>
+      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Cache.$(PackageRID)</Id>
+    </PropertyGroup>
+  </Target>
+
+  <PropertyGroup>
+    <PackageDescription>Contains Emscripten SDK system libraries cache for $(PackageRID).</PackageDescription>
+    <Description>Contains Emscripten SDK system libraries cache for $(PackageRID).</Description>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />
+  <Import Project="..\Directory.Build.targets" />
+</Project>

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Cache/Microsoft.NET.Runtime.Emscripten.Cache.props
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Cache/Microsoft.NET.Runtime.Emscripten.Cache.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <ArtifactsDirToPackage>$(ArtifactsObjDir).cache-sdk\</ArtifactsDirToPackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(ArtifactsDirToPackage)**" TargetPath="tools\%(RecursiveDir)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)eng\sdk_files\Emscripten.Cache.props" TargetPath="Sdk\Sdk.props" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)eng\sdk_files\Emscripten.Cache.targets" TargetPath="Sdk\Sdk.targets" SkipPackageFileCheck="true" />
+  </ItemGroup>
+</Project>

--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.net7.Manifest/WorkloadManifest.json.in
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.net7.Manifest/WorkloadManifest.json.in
@@ -7,6 +7,7 @@
       "packs": [
         "Microsoft.NET.Runtime.Emscripten.Node.net7",
         "Microsoft.NET.Runtime.Emscripten.Python.net7",
+        "Microsoft.NET.Runtime.Emscripten.Cache.net7",
         "Microsoft.NET.Runtime.Emscripten.Sdk.net7"
       ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
@@ -30,6 +31,16 @@
         "win-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Python.win-x64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Python.osx-x64",
         "osx-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Python.osx-x64"
+      }
+    },
+    "Microsoft.NET.Runtime.Emscripten.Cache.net7" : {
+      "kind": "Sdk",
+      "version": "${PackageVersion}",
+      "alias-to": {
+        "win-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.win-x64",
+        "linux-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.linux-x64",
+        "osx-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.osx-x64",
+        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.osx-x64"
       }
     },
     "Microsoft.NET.Runtime.Emscripten.Sdk.net7" : {

--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.net7.Manifest/WorkloadManifest.targets
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.net7.Manifest/WorkloadManifest.targets
@@ -22,5 +22,7 @@
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Python.net7" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Node.net7" />
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Sdk.net7" />
+    <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Cache.net7" />
+    <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.Emscripten.Cache.net7" />
   </ImportGroup>
 </Project>

--- a/eng/sdk_files/Emscripten.Cache.props
+++ b/eng/sdk_files/Emscripten.Cache.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <EmscriptenCacheSdkToolsPath>$(MSBuildThisFileDirectory)..\tools\</EmscriptenCacheSdkToolsPath>
+    <EmscriptenCacheSdkCacheDir>$([MSBuild]::NormalizeDirectory('$(EmscriptenCacheSdkToolsPath)', 'emscripten', 'cache'))</EmscriptenCacheSdkCacheDir>
+  </PropertyGroup>
+
+</Project>

--- a/eng/sdk_files/Emscripten.Cache.targets
+++ b/eng/sdk_files/Emscripten.Cache.targets
@@ -1,0 +1,7 @@
+<Project>
+  <Target Name="_EmscriptenCacheSdkOverrideWasmCachePath" BeforeTargets="_PrepareForWasmBuildNative" Condition="'$(WasmBuildNative)' == 'true'">
+    <PropertyGroup>
+      <WasmCachePath Condition="'$(WasmCachePath)' == ''">$(EmscriptenCacheSdkCacheDir)</WasmCachePath>
+    </PropertyGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
This is a forward port of #208 to `main`


---

Spin out the emscripten system libraries cache into a separate nupkg.

- Split up the Emscripten SDK by moving the system libraries cache into a separate nupkg.

- make a new Emscripten Cache SDK that includes just the cache directory

- the Cache SDK overrides the WasmCachePath (if it's not set by the user) to point into the Cache SDK

   we leave the mt multithreaded libraries in the cache. (But we remove the ww WebWorker (non-pthread) Emscripten API libraries)

Addresses dotnet/runtime#75263