### PR TITLE
Split workloads into packs/components

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,25 +3,25 @@
   <ProductDependencies>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22458.5">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22457.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>622c2dc5ced5df5af002a3b06a52f9584b726b28</Sha>
+      <Sha>e8ed48e43a06ad8faeb1e62b81fbfb53f4cbdc85</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="7.0.0-beta.22458.5">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="7.0.0-beta.22457.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>622c2dc5ced5df5af002a3b06a52f9584b726b28</Sha>
+      <Sha>e8ed48e43a06ad8faeb1e62b81fbfb53f4cbdc85</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="7.0.0-beta.22458.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="7.0.0-beta.22457.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>622c2dc5ced5df5af002a3b06a52f9584b726b28</Sha>
+      <Sha>e8ed48e43a06ad8faeb1e62b81fbfb53f4cbdc85</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22458.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.22457.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>622c2dc5ced5df5af002a3b06a52f9584b726b28</Sha>
+      <Sha>e8ed48e43a06ad8faeb1e62b81fbfb53f4cbdc85</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="7.0.0-beta.22458.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="7.0.0-beta.22457.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>622c2dc5ced5df5af002a3b06a52f9584b726b28</Sha>
+      <Sha>e8ed48e43a06ad8faeb1e62b81fbfb53f4cbdc85</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <MajorVersion>7</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <VersionPrefix>7.0.0</VersionPrefix>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
@@ -14,10 +16,10 @@
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
-    <MicrosoftDotNetBuildTasksPackagingVersion>7.0.0-beta.22458.5</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>7.0.0-beta.22457.4</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.21420.4</MicrosoftDotNetBuildTasksTemplatingVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>7.0.0-beta.22458.5</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>7.0.0-beta.22458.5</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>7.0.0-beta.22457.4</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>7.0.0-beta.22457.4</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -17,6 +17,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IncludeBuildOutput>false</IncludeBuildOutput>
 
+    <VSTemp>$(WorkloadIntermediateOutputPath)VS/</VSTemp>
     <WorkloadIntermediateOutputPath>$(ArtifactsObjDir)workloads/</WorkloadIntermediateOutputPath>
     <VSTemp>$(WorkloadIntermediateOutputPath)VS/</VSTemp>
     <WorkloadOutputPath>$(ArtifactsBinDir)workloads/</WorkloadOutputPath>
@@ -73,7 +74,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Emscripten.*Manifest*.nupkg" />
+      <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Emscripten*.Manifest*.nupkg"
+                        Exclude="$(PackageSource)Microsoft.NET.Workload.Emscripten*.Manifest*.msi*.nupkg"
+                        MsiVersion="$(MsiVersion)"/>
     </ItemGroup>
 
     <Error Text="Could not find any manifest packages in $(PackageSource)"
@@ -82,7 +85,7 @@
     <CreateVisualStudioWorkload BaseIntermediateOutputPath="$(WorkloadIntermediateOutputPath)"
           AllowMissingPacks="True"
           BaseOutputPath="$(WorkloadOutputPath)"
-          ComponentResources="$(ComponentResources)"
+          ComponentResources="@(ComponentResources)"
           PackageSource="$(PackageSource)"
           ShortNames="@(ShortNames)"
           WorkloadManifestPackageFiles="@(ManifestPackages)"
@@ -92,30 +95,45 @@
       <Output TaskParameter="Msis" ItemName="Msis" />
     </CreateVisualStudioWorkload>
 
+    <!-- Split SWIX projects for packs and components/manifests and build them into separate folders. This allows us to consume pack-only drops
+         across multiple VS builds to support multi-targeting. -->
+    <ItemGroup>
+      <SwixWorkloadPackProjects Include="@(SwixProjects)" Condition="'%(PackageType)' == 'msi-pack'"
+                                ManifestOutputPath="$(VStemp)\p\%(SwixProjects.SdkFeatureBand)"
+                                ZipFile="Workload.VSDrop.emsdk.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand).packs.zip"/>
+      <SwixComponentsAndManifests Include="@(SwixProjects)" Condition="'%(PackageType)' == 'msi-manifest' Or '%(PackageType)' == 'component'"
+                                  ManifestOutputPath="$(VStemp)\c\%(SwixProjects.SdkFeatureBand)"
+                                  ZipFile="Workload.VSDrop.emsdk.$(MajorVersion).$(MinorVersion)-%(SwixProjects.SdkFeatureBand).components.zip"/>
+      <PartitionedSwixProjects Include="@(SwixWorkloadPackProjects);@(SwixComponentsAndManifests)" />
+    </ItemGroup>
 
-    <!-- Build all the SWIX projects. This requires full framework MSBuild-->
-    <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VSTemp)%(SwixProjects.SdkFeatureBand)" />
+    <!-- Can't build in parallel to the same output folder because of a shared file from the SWIX compiler. -->
+    <MSBuild Projects="@(PartitionedSwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=%(ManifestOutputPath)"/>
 
-    <!-- Create payload package for VSDROP creation -->
+    <!-- Create the zip files used for VSDROP creation. -->
     <ItemGroup>
       <SdkFeatureBand Include="%(SwixProjects.SdkFeatureBand)" />
     </ItemGroup>
 
+    <ItemGroup>
+      <VSDrop Include="%(PartitionedSwixProjects.ZipFile)" SourceDirectory="%(ManifestOutputPath)" />
+    </ItemGroup>
+
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" />
     <MakeDir Directories="$(VisualStudioSetupInsertionPath)" />
-    <ZipDirectory Overwrite="true" DestinationFile="$(VisualStudioSetupInsertionPath)Workloads.VSDrop.%(SdkFeatureBand.Identity).$(PackageVersion).zip" SourceDirectory="$(VSTemp)%(SdkFeatureBand.Identity)"/>
+
+    <ZipDirectory Overwrite="true" SourceDirectory="%(SourceDirectory)"
+                  DestinationFile="$(VisualStudioSetupInsertionPath)%(VSDrop.Identity)" />
 
     <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
     <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />
-
-
 
     <!-- Build all the MSI payload packages for NuGet. -->
     <ItemGroup>
       <MsiPackageProjects Include="%(Msis.PackageProject)" />
     </ItemGroup>
 
-    <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir)" Targets="restore;pack" />
+    <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir);IncludeSymbols=false" Targets="restore;pack" />
   </Target>
 
   <!-- Target to create a single wixpack for signing -->

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "tools": {
-    "dotnet": "7.0.100-rc.1.22425.9"
+    "dotnet": "7.0.100-rc.1.22431.11"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22458.5",
-    "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22458.5"
+    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22457.4",
+    "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22457.4"
   }
 }


### PR DESCRIPTION
Update Arcade and port changes from 6.0 to split workloads artifacts into separate zips for packs and components/manifests for VS insertions