### PR TITLE
[build] Enable CodeQL with TSA

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\mono",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
+    "repositoryName": "emsdk",
+    "codebaseName": "emsdk"
+}

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -40,3 +40,9 @@ variables:
         /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+    - name: Codeql.Enabled
+      value: True
+    - name: Codeql.BuildIdentifier
+      value: $(System.JobDisplayName)
+    - name: Codeql.TSAEnabled
+      value: True


### PR DESCRIPTION
CodeQL is a static analysis tool that is able to scan source code to help detect security vulnerabilities. In Dotnet/runtime-assets, there already exists auto-injection of CodeQL's init and finalize tasks within the official default pipeline.

This PR does the following:
Enables CodeQL
Enable TSA with CodeQL