### PR TITLE
Fix package unzipping when packed file name contains colon

### DIFF
--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -1,0 +1,22 @@
+name: Build emsdk dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'LLVM Webassembly arm64'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build-llvm-webassembly-arm64:
+
+    runs-on: windows-latest
+
+    steps:
+    
+    - name: Build LLVM WebAssembly arm64
+      run: |
+        set
+        ls

--- a/emsdk.py
+++ b/emsdk.py
@@ -582,7 +582,11 @@ def unzip(source_filename, dest_dir):
       # Now do the actual decompress.
       for member in zf.infolist():
         zf.extract(member, fix_potentially_long_windows_pathname(unzip_to_dir))
-        dst_filename = os.path.join(unzip_to_dir, member.filename)
+        if WINDOWS:
+          filename = member.filename.replace(':', '_')
+        else:
+          filename = member.filename
+        dst_filename = os.path.join(unzip_to_dir, filename)
 
         # See: https://stackoverflow.com/questions/42326428/zipfile-in-python-file-permission
         unix_attributes = member.external_attr >> 16
@@ -592,9 +596,9 @@ def unzip(source_filename, dest_dir):
         # Move the extracted file to its final location without the base
         # directory name, if we are stripping that away.
         if common_subdir:
-          if not member.filename.startswith(common_subdir):
-            raise Exception('Unexpected filename "' + member.filename + '"!')
-          stripped_filename = '.' + member.filename[len(common_subdir):]
+          if not filename.startswith(common_subdir):
+            raise Exception('Unexpected filename "' + filename + '"!')
+          stripped_filename = '.' + filename[len(common_subdir):]
           final_dst_filename = os.path.join(dest_dir, stripped_filename)
           # Check if a directory
           if stripped_filename.endswith('/'):

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -432,6 +432,15 @@
   },
   {
     "id": "python",
+    "version": "3.11.1",
+    "bitness": 64,
+    "arch": "aarch64",
+    "windows_url": "https://www.python.org/ftp/python/3.11.1/python-3.11.1-embed-arm64.zip",
+    "activated_cfg": "PYTHON='%installation_dir%/python.exe'",
+    "activated_env": "EMSDK_PYTHON=%installation_dir%/python.exe"
+  },
+  {
+    "id": "python",
     "version": "3.9.2",
     "bitness": 64,
     "arch": "x86_64",
@@ -739,6 +748,14 @@
     "bitness": 64,
     "uses": ["node-14.18.2-64bit", "python-3.9.2-nuget-64bit", "java-8.152-64bit", "releases-upstream-%releases-tag%-64bit"],
     "os": "win",
+    "custom_install_script": "emscripten_npm_install"
+  },
+  {
+    "version": "releases-upstream-%releases-tag%",
+    "bitness": 64,
+    "uses": ["python-3.11.1-64bit"],
+    "os": "win",
+    "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"
   },
   {


### PR DESCRIPTION
This happens e.g. when installing binaryen using `emsdk install binaryen-tag-1.38.31-64bit`.