### PR TITLE
[release/7.0] Set versions for net6

### DIFF
--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -62,6 +62,10 @@
                           Version="$(AssemblyVersion)"
                           Title=".NET WebAssembly Build Tools (Emscripten)"
                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
+      <ComponentResources Include="microsoft-net-sdk-emscripten-net6"
+                          Version="$(AssemblyVersion)"
+                          Title=".NET WebAssembly Build Tools for .NET6 (Emscripten)"
+                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking on .NET6."/>
     </ItemGroup>
 
     <!-- Shorten package names to avoid long path issues in Visual Studio -->


### PR DESCRIPTION
Fix net6 workload component versions. net7 version of https://github.com/dotnet/emsdk/pull/279