### PR TITLE
Add a baseline SourceBuild.props

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>emsdk</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Yes, this indicates managed artifacts only. For now, we are only attempting to source-build the emsdk manifest, not the full packages, so the statement is true.

Needed to add emsdk to source-build/VMR, and prevent:

```  
/home/directhex/Projects/dotnet/src/emsdk/artifacts/obj/ArcadeGeneratedProjects/SourceBuildIntermediate/SourceBuildIntermediate.proj(43,5): error : GitHubRepositoryName property is not defined.
```