### PR TITLE
Use .Transport instead of _Transport in unversioned manifest name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ __pycache__
 # Tags files that get generated at runtime
 /emscripten-releases-tot.txt
 
+### OSX ###
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
 # File that get download/extracted by emsdk itself
 /ccache
 /gnu

--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/Microsoft.NET.Workload.Emscripten.Current.Manifest.pkgproj
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/Microsoft.NET.Workload.Emscripten.Current.Manifest.pkgproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup Condition="'$(IsUnversionedManifest)' == 'true'">
     <IsShipping>false</IsShipping>
-    <WorkloadVersionSuffix>_Transport</WorkloadVersionSuffix>
+    <WorkloadVersionSuffix>.Transport</WorkloadVersionSuffix>
   </PropertyGroup>
 
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">


### PR DESCRIPTION
All others use .Transport.