### PR TITLE
Disable TFM trimming

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>emsdk</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3336

The issue was introduced by https://github.com/dotnet/emsdk/pull/312, which isn't currently needed in this repo. As a result none of the projects were built in source-build which introduced 3 prebuilts.