### PR TITLE
Move NoTargetFrameworkFiltering property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,11 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <PropertyGroup>
+    <!-- Emsdk doesn't support Arcade-driven target framework filtering. -->
+    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(StabilizePackageVersion)' == 'true'">
     <StableVersion>$(VersionPrefix)</StableVersion>
   </PropertyGroup>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>emsdk</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/3417

This is a backport of the patch, implemented in `installer` with https://github.com/dotnet/installer/pull/16214

`NoTargetFrameworkFiltering` property, in `emsdk` repo, should be moved from `eng/SourceBuild.props` to `Directory.Build.props`. 

This would match the implementation in the `runtime` repo (https://github.com/dotnet/runtime/blob/018a9bd43851c998f9239aedf2fcc09c5eff7488/Directory.Build.props#L304-L305).