### PR TITLE
Revert "Bump downlevel version to 7.0.7"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
     <EmscriptenVersion>3.1.34</EmscriptenVersion>
     <EmscriptenVersionNet6>2.0.23</EmscriptenVersionNet6>
     <EmscriptenVersionNet7>3.1.12</EmscriptenVersionNet7>
-    <PackageVersionNet7>7.0.7</PackageVersionNet7>
+    <PackageVersionNet7>7.0.6</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet7)').Build),11))</PackageVersionNet6>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Reverts dotnet/emsdk#349 I'm going to roll this back so main can still test downlevel