### PR TITLE
Do not publish wixpacks when postbuild sign is not true

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_InstallersToPublish Include="$(ArtifactsDir)**\*.wixpack.zip" />
+    <_InstallersToPublish Include="$(ArtifactsDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' == 'true'" />
     <_InstallerManifestFilesToPublish Include="$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\**\*.zip" />
   </ItemGroup>
 


### PR DESCRIPTION
Saves about 500MB of artifacts.