### PR TITLE
Allow WebAssembly SDK without workload

### DIFF
--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.targets
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.targets
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(BrowserWorkloadDisabled)' != 'true'">
-    <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true'" >true</UsingBrowserRuntimeWorkload>
+    <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or '$(UsingMicrosoftNETSdkBlazorWebAssembly)' != 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' != 'true'" >true</UsingBrowserRuntimeWorkload>
     <UsingBrowserRuntimeWorkload Condition="'$(UsingBrowserRuntimeWorkload)' == ''" >$(WasmNativeWorkload)</UsingBrowserRuntimeWorkload>
   </PropertyGroup>
 


### PR DESCRIPTION
Similar to how Blazor SDK supports building app without workload, WebAssembly SDK should too.