### PR TITLE
[release/6.0] emscripten: Fix workload manifest MSI ProductVersion generation

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
+    <PatchVersion>22</PatchVersion>
     <VersionPrefix>6.0.22</VersionPrefix>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -50,13 +50,13 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
+  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
       <ComponentResources Include="microsoft-net-sdk-emscripten" Title=".NET WebAssembly Build Tools (Emscripten)"
                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."
-                          Version="$(AssemblyVersion)" />
+                          Version="$(FileVersion)" />
     </ItemGroup>
 
     <!-- BAR requires having version information in blobs -->
@@ -167,15 +167,6 @@
     <MSBuild Projects="@(VisualStudioManifestProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath);OutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
   </Target>
 
-  <Target Name="_GetVersionProps">
-    <PropertyGroup>
-      <_MajorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Major)</_MajorVersion>
-      <_MinorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Minor)</_MinorVersion>
-      <_PatchVersion>$([System.Version]::Parse('$(AssemblyVersion)').Build)</_PatchVersion>
-      <_BuildNumber>$([System.Version]::Parse('$(AssemblyVersion)').Revision)</_BuildNumber>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="_GenerateMsiVersionString">
     <PropertyGroup>
       <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
@@ -193,9 +184,9 @@
     </GenerateCurrentVersion>
 
     <GenerateMsiVersion
-      Major="$(_MajorVersion)"
-      Minor="$(_MinorVersion)"
-      Patch="$(_PatchVersion)"
+      Major="$(MajorVersion)"
+      Minor="$(MinorVersion)"
+      Patch="$(PatchVersion)"
       BuildNumberMajor="$(BuildNumberMajor)"
       BuildNumberMinor="$(BuildNumberMinor)">
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />


### PR DESCRIPTION
# Description

Manifest installers for .NET optional workloads rely on performing major upgrades in .NET 6 and 7. This requires that the MSI version increments for new builds. The MSI version was generated using the assembly file version. MSI versions should be generated using the major/minor/patch/buildnumber, e.g. 6.0.20.12345. Because the assembly file version was being used, the version will eventually get wrapped due to the bit masking and shift operations used to construct the MSI version. MSI [ProductVersion](https://learn.microsoft.com/en-us/windows/win32/msi/productversion) is only 32-bits in size (8-bit major, 8-bit minor and 16-bit build number).

For 6.0.21, the ProductVersion generated using the old method was 48.35.64643 and for 6.0.22 it generated 48.32.658.

# Impact

1. Visual Studio PR checks fail package validation because the new MSI's version is lower than the baseline copy from the previous insertion.
2. The CLI will block installing the newer manifest when trying to update workloads because it will detect a possible downgrade.

# Testing

No unit tests for this. Validated using Orca to ensure the manifest MSI's ProductVersion matches the version we generate for other runtime MSIs.

![image](https://github.com/dotnet/emsdk/assets/7409981/87643537-c4a1-41e1-8dec-f4b14a55c511)

The generated component manifest for the emscripten workload in Visual Studio using an internal build was also validated. The  component uses the runtime's AssemblyFileVersion as it can rely on a standard 4-part version number.

```json
{
  "manifestVersion": "1.1",
  "info": {
    "id": "microsoft.net.sdk.emscripten,version=6.0.8.42203"
  },
  "packages": [
    {
      "id": "microsoft.net.sdk.emscripten",
      "version": "6.0.8.42203",
      "type": "Component",
```