### PR TITLE
[release/7.0] emscripten: Fix workload manifest MSI ProductVersion generation

### DIFF
--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -52,18 +52,18 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
+  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Visual Studio components must be versioned. Build tasks will fall back to cobbling a version number from
         the manifest information unless it's overridden. -->
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
             these must be updated. -->
       <ComponentResources Include="microsoft-net-sdk-emscripten-net7"
-                          Version="$(AssemblyVersion)"
+                          Version="$(FileVersion)"
                           Title=".NET WebAssembly Build Tools (Emscripten)"
                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
       <ComponentResources Include="microsoft-net-sdk-emscripten-net6"
-                          Version="$(AssemblyVersion)"
+                          Version="$(FileVersion)"
                           Title=".NET WebAssembly Build Tools for .NET6 (Emscripten)"
                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking on .NET6."/>
     </ItemGroup>
@@ -169,15 +169,6 @@
     <MSBuild Projects="@(SwixProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VisualStudioSetupInsertionPath)" />
   </Target>
 
-  <Target Name="_GetVersionProps">
-    <PropertyGroup>
-      <_MajorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Major)</_MajorVersion>
-      <_MinorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Minor)</_MinorVersion>
-      <_PatchVersion>$([System.Version]::Parse('$(AssemblyVersion)').Build)</_PatchVersion>
-      <_BuildNumber>$([System.Version]::Parse('$(AssemblyVersion)').Revision)</_BuildNumber>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="_GenerateMsiVersionString">
     <PropertyGroup>
       <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
@@ -195,9 +186,9 @@
     </GenerateCurrentVersion>
 
     <GenerateMsiVersion
-      Major="$(_MajorVersion)"
-      Minor="$(_MinorVersion)"
-      Patch="$(_PatchVersion)"
+      Major="$(MajorVersion)"
+      Minor="$(MinorVersion)"
+      Patch="$(PatchVersion)"
       BuildNumberMajor="$(BuildNumberMajor)"
       BuildNumberMinor="$(BuildNumberMinor)">
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />


### PR DESCRIPTION
# Description
Manifest installers for .NET optional workloads rely on performing major upgrades in .NET 6 and 7. This requires that the MSI version increments for new builds. The MSI version was generated using the assembly file version. MSI versions should be generated using the major/minor/patch/buildnumber, e.g. 7.0.10.12345. Because the assembly file version was being used, the version will eventually get wrapped due to the bit masking and shift operations used to construct the MSI version. MSI [ProductVersion](https://learn.microsoft.com/en-us/windows/win32/msi/productversion) is only 32-bits in size (8-bit major, 8-bit minor and 16-bit build number).

For 7.0.10, the ProductVersion generated using the old method was 56.35.64642 and for 7.0.11 it generated 56.32.531

# Impact
Visual Studio PR checks fail package validation because the new MSI's version is lower than the baseline copy from the previous insertion.
The CLI will block installing the newer manifest when trying to update workloads because it will detect a possible downgrade.

# Testing

Manually verify the generated workload MSIs and Visual Studio components for the manifest installers.