### PR TITLE
Fix manifest MSI version generation

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <VersionPrefix>8.0.0</VersionPrefix>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -52,22 +52,22 @@
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
+  <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GenerateMsiVersionString">
     <ItemGroup>
       <!-- Visual Studio components must be versioned. Build tasks will fall back to cobbling a version number from
         the manifest information unless it's overridden. -->
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
             these must be updated. -->
       <ComponentResources Include="microsoft-net-sdk-emscripten"
-                          Version="$(AssemblyVersion)"
+                          Version="$(FileVersion)"
                           Title=".NET WebAssembly Build Tools (Emscripten)"
                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
       <ComponentResources Include="microsoft-net-sdk-emscripten-net7"
-                          Version="$(AssemblyVersion)"
+                          Version="$(FileVersion)"
                           Title=".NET WebAssembly Build Tools for .NET7 (Emscripten)"
                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking on .NET7."/>
       <ComponentResources Include="microsoft-net-sdk-emscripten-net6"
-                          Version="$(AssemblyVersion)"
+                          Version="$(FileVersion)"
                           Title=".NET WebAssembly Build Tools for .NET6 (Emscripten)"
                           Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking on .NET6."/>
     </ItemGroup>
@@ -177,15 +177,6 @@
     <MSBuild Projects="@(SwixProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VisualStudioSetupInsertionPath)" />
   </Target>
 
-  <Target Name="_GetVersionProps">
-    <PropertyGroup>
-      <_MajorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Major)</_MajorVersion>
-      <_MinorVersion>$([System.Version]::Parse('$(AssemblyVersion)').Minor)</_MinorVersion>
-      <_PatchVersion>$([System.Version]::Parse('$(AssemblyVersion)').Build)</_PatchVersion>
-      <_BuildNumber>$([System.Version]::Parse('$(AssemblyVersion)').Revision)</_BuildNumber>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="_GenerateMsiVersionString">
     <PropertyGroup>
       <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
@@ -203,9 +194,9 @@
     </GenerateCurrentVersion>
 
     <GenerateMsiVersion
-      Major="$(_MajorVersion)"
-      Minor="$(_MinorVersion)"
-      Patch="$(_PatchVersion)"
+      Major="$(MajorVersion)"
+      Minor="$(MinorVersion)"
+      Patch="$(PatchVersion)"
       BuildNumberMajor="$(BuildNumberMajor)"
       BuildNumberMinor="$(BuildNumberMinor)">
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />


### PR DESCRIPTION
This is a port of the recent version fixes for manifest installers.

See the following for the 6/7 changes.

https://github.com/dotnet/emsdk/pull/441
https://github.com/dotnet/emsdk/pull/440

We need this before 8.0 ships so we are consistent across the board.