### PR TITLE
Add home-made emsdk_env.sh

### DIFF
--- a/eng/emsdk_env.sh
+++ b/eng/emsdk_env.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+echo "*** .NET EMSDK path setup ***"
+
+# emscripten (emconfigure, em++, etc)
+if [ -z "${EMSDK_PATH}" ]; then
+  echo "\$EMSDK_PATH is empty"
+  exit 1
+fi
+TOADD_PATH_EMSCRIPTEN="$(realpath ${EMSDK_PATH}/emscripten)"
+echo "PATH += ${TOADD_PATH_EMSCRIPTEN}"
+export PATH=${TOADD_PATH_EMSCRIPTEN}:$PATH
+
+# llvm (clang, etc)
+if [ -z "${DOTNET_EMSCRIPTEN_LLVM_ROOT}" ]; then
+  echo "\$DOTNET_EMSCRIPTEN_LLVM_ROOT is empty"
+  exit 1
+fi
+TOADD_PATH_LLVM="$(realpath ${DOTNET_EMSCRIPTEN_LLVM_ROOT})"
+if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_LLVM}" ]; then
+  echo "PATH += ${TOADD_PATH_LLVM}"
+  export PATH=${TOADD_PATH_LLVM}:$PATH
+fi
+
+# nodejs (node)
+if [ -z "${DOTNET_EMSCRIPTEN_NODE_JS}" ]; then
+  echo "\$DOTNET_EMSCRIPTEN_NODE_JS is empty"
+  exit 1
+fi
+TOADD_PATH_NODEJS="$(dirname ${DOTNET_EMSCRIPTEN_NODE_JS})"
+if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_NODEJS}" ] && [ "${TOADD_PATH_LLVM}" != "${TOADD_PATH_NODEJS}" ]; then
+  echo "PATH += ${TOADD_PATH_NODEJS}"
+  export PATH=${TOADD_PATH_NODEJS}:$PATH
+fi
+
+# binaryen (wasm-opt, etc)
+if [ -z "${DOTNET_EMSCRIPTEN_BINARYEN_ROOT}" ]; then
+  echo "\$DOTNET_EMSCRIPTEN_BINARYEN_ROOT is empty"
+  exit 1
+fi
+TOADD_PATH_BINARYEN="$(realpath ${DOTNET_EMSCRIPTEN_BINARYEN_ROOT}/bin)"
+if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_BINARYEN}" ] && [ "${TOADD_PATH_LLVM}" != "${TOADD_PATH_BINARYEN}" ] && [ "${TOADD_PATH_NODEJS}" != "${TOADD_PATH_BINARYEN}" ]; then
+  echo "PATH += ${TOADD_PATH_BINARYEN}"
+  export PATH=${TOADD_PATH_BINARYEN}:$PATH
+fi

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Sdk/Microsoft.NET.Runtime.Emscripten.Sdk.props
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Sdk/Microsoft.NET.Runtime.Emscripten.Sdk.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <File Include="$(ArtifactsDirToPackage)**" TargetPath="tools\%(RecursiveDir)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)eng\.emscripten" TargetPath="tools\emscripten" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)eng\emsdk_env.sh" TargetPath="tools" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)eng\sdk_files\Emscripten.Sdk.props" TargetPath="Sdk\Sdk.props" SkipPackageFileCheck="true" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Would you believe this change is sufficient to enable building ICU with our emsdk (when paired with a lot of env vars)?

I was originally going to ship the upstream emsdk_env.sh, but that carries a LOT of dependencies on other files from the emsdk repo, and also the `construct_env` command doesn't work properly unless the directory layout is very specific, which is a problem for us. Instead, a simple script to add our env vars (which we already use in wasm publishing) to $PATH in the same manner, bypassing the need for emsdk.py entirely.