### PR TITLE
Check DotNetFinalVersionKind when setting WorkloadVersionSuffix

### DIFF
--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Common.props
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Common.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <WorkloadVersionSuffix Condition="'$(PreReleaseVersionLabel)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
+    <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This issue was found during the .NET 8 Test build. Fixes https://dev.azure.com/dnceng/internal/_build/results?buildId=2260881&view=results