### PR TITLE
Don't stabilize non shipping package

### DIFF
--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/Microsoft.NET.Workload.Emscripten.Current.Manifest.pkgproj
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/Microsoft.NET.Workload.Emscripten.Current.Manifest.pkgproj
@@ -13,6 +13,8 @@
   <PropertyGroup Condition="'$(IsUnversionedManifest)' == 'true'">
     <IsShipping>false</IsShipping>
     <WorkloadVersionSuffix>.Transport</WorkloadVersionSuffix>
+    <VersionSuffix>$(_PreReleaseLabel)$(_BuildNumberLabels)</VersionSuffix>
+    <StableVersion></StableVersion>
   </PropertyGroup>
 
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" Returns="@(PackageFile)">


### PR DESCRIPTION
Microsoft.NET.Workload.Emscripten.Current.Manifest is a non shipping package and shouldn't have a stable version