### PR TITLE
[release/8.0] Pass emscripten path as argument to Sanitize.py

### DIFF
--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -205,7 +205,7 @@
       IgnoreStandardErrorWarningFormat="true" />
 
     <Exec WorkingDirectory="$(RepoRoot)"
-      Command="$(PythonPath) eng/sanitize.py $(RepoRoot) $([System.IO.Directory]::GetParent($(HostNodeDir)))" />
+      Command="$(PythonPath) eng/sanitize.py $(EmscriptenDir) $([System.IO.Directory]::GetParent($(HostNodeDir)))" />
     <!-- clang-wrapper.sh hardcodes clang-16 at the moment so make sure it still exists -->
     <Error Text="Update clang-wrapper.sh to point at the correct clang-* version"
       Condition="!Exists('$(LLVMDir)\bin\clang-16') and !$([MSBuild]::IsOSPlatform(Windows))" />

--- a/eng/sanitize.py
+++ b/eng/sanitize.py
@@ -31,9 +31,8 @@ def rewrite_package_json(path):
     package.close()
 
 
-emsdk_path = sys.argv[1]
+emscripten_path = sys.argv[1]
 node_root = sys.argv[2]
-emscripten_path = os.path.join(emsdk_path, "emscripten", "8.0.0")
 node_paths = glob(node_root)
 upgrade = False
 


### PR DESCRIPTION
Currently, the emscripten version is hardcoded to 8.0.0. This won't work when we move to 8.0.1 (https://dev.azure.com/dnceng/internal/_build/results?buildId=2273068&view=results) This should fix the issue