### PR TITLE
Fix clang-wrapper.sh so it handles arguments with spaces.

### DIFF
--- a/eng/clang-wrapper.sh
+++ b/eng/clang-wrapper.sh
@@ -22,4 +22,4 @@ case $CLANG_NAME in
         ;;
 esac
 
-$CLANG_CC $EXTRA_ARGS $@
+$CLANG_CC $EXTRA_ARGS "$@"

--- a/eng/clang-wrapper.sh
+++ b/eng/clang-wrapper.sh
@@ -22,4 +22,4 @@ case $CLANG_NAME in
         ;;
 esac
 
-$CLANG_CC $EXTRA_ARGS "$@"
+"$CLANG_CC" $EXTRA_ARGS "$@"


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/92335.