### PR TITLE
Emscripten.Cache.*: Set WasmCachePath in Sdk.props instead of in a target

### DIFF
--- a/eng/sdk_files/Emscripten.Cache.props
+++ b/eng/sdk_files/Emscripten.Cache.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <EmscriptenCacheSdkToolsPath>$(MSBuildThisFileDirectory)..\tools\</EmscriptenCacheSdkToolsPath>
     <EmscriptenCacheSdkCacheDir>$([MSBuild]::NormalizeDirectory('$(EmscriptenCacheSdkToolsPath)', 'emscripten', 'cache'))</EmscriptenCacheSdkCacheDir>
+    <WasmCachePath Condition="'$(WasmCachePath)' == ''">$(EmscriptenCacheSdkCacheDir)</WasmCachePath>
   </PropertyGroup>
 
 </Project>

--- a/eng/sdk_files/Emscripten.Cache.targets
+++ b/eng/sdk_files/Emscripten.Cache.targets
@@ -1,7 +1,1 @@
-<Project>
-  <Target Name="_EmscriptenCacheSdkOverrideWasmCachePath" BeforeTargets="_PrepareForWasmBuildNative" Condition="'$(WasmBuildNative)' == 'true'">
-    <PropertyGroup>
-      <WasmCachePath Condition="'$(WasmCachePath)' == ''">$(EmscriptenCacheSdkCacheDir)</WasmCachePath>
-    </PropertyGroup>
-  </Target>
-</Project>
+<Project />


### PR DESCRIPTION
This removes the dependence on a target to set this.