### PR TITLE
Add missing workload references to Musl native EMSDK

### DIFF
--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.json.in
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.json.in
@@ -10,7 +10,7 @@
         "Microsoft.NET.Runtime.Emscripten.Cache",
         "Microsoft.NET.Runtime.Emscripten.Sdk"
       ],
-      "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ]
+      "platforms": [ "win-x64", "win-arm64", "linux-x64", "linux-arm64", "linux-musl-x64", "linux-musl-arm64", "osx-x64", "osx-arm64" ]
     }
   },
   "packs": {
@@ -22,6 +22,8 @@
         "win-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.win-arm64",
         "linux-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.linux-x64",
         "linux-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.linux-arm64",
+        "linux-musl-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.linux-musl-x64",
+        "linux-musl-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.linux-musl-arm64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.osx-x64",
         "osx-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Node.osx-arm64"
       }
@@ -44,6 +46,8 @@
         "win-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.win-arm64",
         "linux-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.linux-x64",
         "linux-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.linux-arm64",
+        "linux-musl-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.linux-musl-x64",
+        "linux-musl-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.linux-musl-arm64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.osx-x64",
         "osx-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Cache.osx-arm64"
       }
@@ -56,6 +60,8 @@
         "win-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.win-arm64",
         "linux-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.linux-x64",
         "linux-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.linux-arm64",
+        "linux-musl-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.linux-musl-x64",
+        "linux-musl-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.linux-musl-arm64",
         "osx-x64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.osx-x64",
         "osx-arm64": "Microsoft.NET.Runtime.Emscripten.${EmscriptenVersion}.Sdk.osx-arm64"
       }


### PR DESCRIPTION
Should be the missing fix for https://github.com/dotnet/sdk/issues/32327 though likely these changes need to flow though to updated runtime (and maybe SDK) builds.