### PR TITLE
[release/6.0] Set ProducesDotNetReleaseShippingAssets property in Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -4,6 +4,7 @@
       <PublishingVersion>3</PublishingVersion>
       <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages> <!-- we don't need symbol packages for emsdk -->
       <PostBuildSign>true</PostBuildSign>
+      <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
    </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Backport of https://github.com/dotnet/emsdk/pull/685 to release/6.0