### PR TITLE
Add metadata for workload automation

### DIFF
--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -121,7 +121,7 @@
       <VSDropMetadata Include="$(BUILD_SOURCEBRANCH)"/>
     </ItemGroup>
 
-    <WriteLinesToFile File="%(VSDrop.ManifestOutputPath)\.metadata" Lines="@(VSDropMetadata)" Overwrite="true" Condition="'$(OfficialBuild)' == 'true'" />
+    <WriteLinesToFile File="%(VSDrop.SourceDirectory)\.metadata" Lines="@(VSDropMetadata)" Overwrite="true" Condition="'$(OfficialBuild)' == 'true'" />
 
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" />
     <MakeDir Directories="$(VisualStudioSetupInsertionPath)" />

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -114,6 +114,15 @@
       <VSDrop Include="%(PartitionedSwixProjects.ZipFile)" SourceDirectory="%(ManifestOutputPath)" />
     </ItemGroup>
 
+    <!-- Generate metadata for VSDROP automation. This information cannot be obtained during staging when insertions are triggered -->
+    <ItemGroup>
+      <VSDropMetadata Include="$(FileVersion)" />
+      <VSDropMetadata Include="$(BUILD_REPOSITORY_NAME)" />
+      <VSDropMetadata Include="$(BUILD_SOURCEBRANCH)"/>
+    </ItemGroup>
+
+    <WriteLinesToFile File="%(VSDrop.ManifestOutputPath)\.metadata" Lines="@(VSDropMetadata)" Overwrite="true" Condition="'$(OfficialBuild)' == 'true'" />
+
     <MakeDir Directories="$(ArtifactsNonShippingPackagesDir)" />
     <MakeDir Directories="$(VisualStudioSetupInsertionPath)" />
 


### PR DESCRIPTION
# Description

To automate VSDROP insertions from staging builds, we need to include some additional metadata that is difficult to obtain from staging builds, like the assembly file version that is used when versioning drop components.

# Testing

Manually verified metadata against internal builds. Cannot be fully tested until we have a fully staged build and all the automation pipelines completed.