### PR TITLE
[release/9.0-preview4] Bump downlevel versions to 8.0.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
     <EmscriptenVersionNet8>3.1.34</EmscriptenVersionNet8>
     <EmscriptenVersionNet7>3.1.12</EmscriptenVersionNet7>
     <EmscriptenVersionNet6>2.0.23</EmscriptenVersionNet6>
-    <PackageVersionNet8>8.0.2</PackageVersionNet8>
+    <PackageVersionNet8>8.0.5</PackageVersionNet8>
     <PackageVersionNet7>7.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet8)').Build),14))</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet7)').Build),11))</PackageVersionNet6>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>9.0.0-alpha.1.24208.2</runtimelinuxarm64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>


### PR DESCRIPTION
this can be fast merged if we're taking it, I think we need it to insert into vs, no of the tests test downlevel