### PR TITLE
Revert "[release/8.0] Pin the net7.0 version at 7.0.19"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,8 +12,8 @@
     <EmscriptenVersion>3.1.34</EmscriptenVersion>
     <EmscriptenVersionNet6>2.0.23</EmscriptenVersionNet6>
     <EmscriptenVersionNet7>3.1.12</EmscriptenVersionNet7>
-    <PackageVersionNet7>7.0.19</PackageVersionNet7>
-    <PackageVersionNet6>6.0.$([MSBuild]::Add($(PatchVersion),25))</PackageVersionNet6>
+    <PackageVersionNet7>7.0.$([MSBuild]::Add($(PatchVersion),14))</PackageVersionNet7>
+    <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet7)').Build),11))</PackageVersionNet6>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>8.0.0-rtm.24212.2</runtimelinuxarm64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>
     <runtimelinuxx64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>8.0.0-rtm.24212.2</runtimelinuxx64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>
     <runtimeosxarm64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>8.0.0-rtm.24212.2</runtimeosxarm64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>


### PR DESCRIPTION
Reverts dotnet/emsdk#784 to prepare for 7.0.20