### PR TITLE
[wasm] move emsdk config and `emsdk_env` files from runtime to emsdk

### DIFF
--- a/eng/.emscripten
+++ b/eng/.emscripten
@@ -1,9 +1,10 @@
 import os
 
-LLVM_ROOT = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_LLVM_ROOT', ''))
-NODE_JS = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_NODE_JS', ''))
-BINARYEN_ROOT = os.path.expanduser(os.getenv('DOTNET_EMSCRIPTEN_BINARYEN_ROOT', ''))
+emsdk_path = os.path.dirname(os.path.dirname(os.path.realpath(os.getenv('EM_CONFIG')).replace('\\', '/')))
 
+LLVM_ROOT = emsdk_path + '/bin'
+NODE_JS = emsdk_path + '/node/bin/node'
+BINARYEN_ROOT = emsdk_path
 FROZEN_CACHE = bool(os.getenv('FROZEN_CACHE', 'True'))
 
 COMPILER_ENGINE = NODE_JS

--- a/eng/emsdk_env.cmd
+++ b/eng/emsdk_env.cmd
@@ -1,10 +1,20 @@
 @echo off
+
+set CURRENT_SCRIPT=%~dp0
+set EMSDK_PATH=%CURRENT_SCRIPT:~0,-1%\
+
+set EMSDK_PYTHON=%EMSDK_PATH%python\python.exe
+set DOTNET_EMSCRIPTEN_LLVM_ROOT=%EMSDK_PATH%bin\
+set DOTNET_EMSCRIPTEN_NODE_JS=%EMSDK_PATH%node\bin\node
+set DOTNET_EMSCRIPTEN_NODE_PATH=%EMSDK_PATH%node\bin\
+set DOTNET_EMSCRIPTEN_BINARYEN_ROOT=%EMSDK_PATH%
+@echo off
 echo *** .NET EMSDK path setup ***
 
 REM emscripten (emconfigure, em++, etc)
 if "%EMSDK_PATH%"=="" (
-  echo %EMSDK_PATH% is empty
-  exit /b 1
+echo %EMSDK_PATH% is empty
+exit /b 1
 )
 set "TOADD_PATH_EMSCRIPTEN=%EMSDK_PATH%emscripten"
 echo PATH += %TOADD_PATH_EMSCRIPTEN%
@@ -12,8 +22,8 @@ set "PATH=%TOADD_PATH_EMSCRIPTEN%;%PATH%"
 
 REM python
 if "%EMSDK_PYTHON%"=="" (
-  echo %EMSDK_PYTHON% is empty
-  exit /b 1
+echo %EMSDK_PYTHON% is empty
+exit /b 1
 )
 set "TOADD_PATH_PYTHON=%EMSDK_PYTHON%"
 echo PATH += %TOADD_PATH_PYTHON%
@@ -21,44 +31,44 @@ set "PATH=%TOADD_PATH_PYTHON%;%PATH%"
 
 REM llvm (clang, etc)
 if "%DOTNET_EMSCRIPTEN_LLVM_ROOT%"=="" (
-  echo %DOTNET_EMSCRIPTEN_LLVM_ROOT% is empty
-  exit /b 1
+echo %DOTNET_EMSCRIPTEN_LLVM_ROOT% is empty
+exit /b 1
 )
 set "TOADD_PATH_LLVM=%DOTNET_EMSCRIPTEN_LLVM_ROOT%"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_LLVM%" (
-  echo PATH += %TOADD_PATH_LLVM%
-  set "PATH=%TOADD_PATH_LLVM%;%PATH%"
+echo PATH += %TOADD_PATH_LLVM%
+set "PATH=%TOADD_PATH_LLVM%;%PATH%"
 )
 
 REM nodejs (node)
 if "%DOTNET_EMSCRIPTEN_NODE_JS%"=="" (
-  echo %DOTNET_EMSCRIPTEN_NODE_JS% is empty
-  exit /b 1
+echo %DOTNET_EMSCRIPTEN_NODE_JS% is empty
+exit /b 1
 )
 if "%DOTNET_EMSCRIPTEN_NODE_PATH%"=="" (
-  echo %DOTNET_EMSCRIPTEN_NODE_PATH% is empty
-  exit /b 1
+echo %DOTNET_EMSCRIPTEN_NODE_PATH% is empty
+exit /b 1
 )
 set "TOADD_PATH_NODEJS=%DOTNET_EMSCRIPTEN_NODE_JS%"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_NODEJS%" (
-  if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_NODEJS%" (
-    echo NODE PATH += %TOADD_PATH_NODEJS%
-    set "PATH=%TOADD_PATH_NODEJS%;%PATH%"
-    set "PATH=%DOTNET_EMSCRIPTEN_NODE_PATH%;%PATH%"
-  )
+if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_NODEJS%" (
+echo NODE PATH += %TOADD_PATH_NODEJS%
+set "PATH=%TOADD_PATH_NODEJS%;%PATH%"
+set "PATH=%DOTNET_EMSCRIPTEN_NODE_PATH%;%PATH%"
+)
 )
 
 REM binaryen (wasm-opt, etc)
 if "%DOTNET_EMSCRIPTEN_BINARYEN_ROOT%"=="" (
-  echo %DOTNET_EMSCRIPTEN_BINARYEN_ROOT% is empty
-  exit /b 1
+echo %DOTNET_EMSCRIPTEN_BINARYEN_ROOT% is empty
+exit /b 1
 )
 set "TOADD_PATH_BINARYEN=%DOTNET_EMSCRIPTEN_BINARYEN_ROOT%bin"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_BINARYEN%" (
-  if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_BINARYEN%" (
-    if not "%TOADD_PATH_NODEJS%"=="%TOADD_PATH_BINARYEN%" (
-      echo PATH += %TOADD_PATH_BINARYEN%
-      set "PATH=%TOADD_PATH_BINARYEN%;%PATH%"
-    )
-  )
+if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_BINARYEN%" (
+if not "%TOADD_PATH_NODEJS%"=="%TOADD_PATH_BINARYEN%" (
+echo PATH += %TOADD_PATH_BINARYEN%
+set "PATH=%TOADD_PATH_BINARYEN%;%PATH%"
+)
+)
 )

--- a/eng/emsdk_env.cmd
+++ b/eng/emsdk_env.cmd
@@ -8,13 +8,14 @@ set DOTNET_EMSCRIPTEN_LLVM_ROOT=%EMSDK_PATH%bin\
 set DOTNET_EMSCRIPTEN_NODE_JS=%EMSDK_PATH%node\bin\node
 set DOTNET_EMSCRIPTEN_NODE_PATH=%EMSDK_PATH%node\bin\
 set DOTNET_EMSCRIPTEN_BINARYEN_ROOT=%EMSDK_PATH%
+
 @echo off
 echo *** .NET EMSDK path setup ***
 
 REM emscripten (emconfigure, em++, etc)
 if "%EMSDK_PATH%"=="" (
-echo %EMSDK_PATH% is empty
-exit /b 1
+    echo %EMSDK_PATH% is empty
+    exit /b 1
 )
 set "TOADD_PATH_EMSCRIPTEN=%EMSDK_PATH%emscripten"
 echo PATH += %TOADD_PATH_EMSCRIPTEN%
@@ -22,8 +23,8 @@ set "PATH=%TOADD_PATH_EMSCRIPTEN%;%PATH%"
 
 REM python
 if "%EMSDK_PYTHON%"=="" (
-echo %EMSDK_PYTHON% is empty
-exit /b 1
+    echo %EMSDK_PYTHON% is empty
+    exit /b 1
 )
 set "TOADD_PATH_PYTHON=%EMSDK_PYTHON%"
 echo PATH += %TOADD_PATH_PYTHON%
@@ -31,44 +32,44 @@ set "PATH=%TOADD_PATH_PYTHON%;%PATH%"
 
 REM llvm (clang, etc)
 if "%DOTNET_EMSCRIPTEN_LLVM_ROOT%"=="" (
-echo %DOTNET_EMSCRIPTEN_LLVM_ROOT% is empty
-exit /b 1
+    echo %DOTNET_EMSCRIPTEN_LLVM_ROOT% is empty
+    exit /b 1
 )
 set "TOADD_PATH_LLVM=%DOTNET_EMSCRIPTEN_LLVM_ROOT%"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_LLVM%" (
-echo PATH += %TOADD_PATH_LLVM%
-set "PATH=%TOADD_PATH_LLVM%;%PATH%"
+    echo PATH += %TOADD_PATH_LLVM%
+    set "PATH=%TOADD_PATH_LLVM%;%PATH%"
 )
 
 REM nodejs (node)
 if "%DOTNET_EMSCRIPTEN_NODE_JS%"=="" (
-echo %DOTNET_EMSCRIPTEN_NODE_JS% is empty
-exit /b 1
+    echo %DOTNET_EMSCRIPTEN_NODE_JS% is empty
+    exit /b 1
 )
 if "%DOTNET_EMSCRIPTEN_NODE_PATH%"=="" (
-echo %DOTNET_EMSCRIPTEN_NODE_PATH% is empty
-exit /b 1
+    echo %DOTNET_EMSCRIPTEN_NODE_PATH% is empty
+    exit /b 1
 )
 set "TOADD_PATH_NODEJS=%DOTNET_EMSCRIPTEN_NODE_JS%"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_NODEJS%" (
-if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_NODEJS%" (
-echo NODE PATH += %TOADD_PATH_NODEJS%
-set "PATH=%TOADD_PATH_NODEJS%;%PATH%"
-set "PATH=%DOTNET_EMSCRIPTEN_NODE_PATH%;%PATH%"
-)
+    if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_NODEJS%" (
+        echo NODE PATH += %TOADD_PATH_NODEJS%
+        set "PATH=%TOADD_PATH_NODEJS%;%PATH%"
+        set "PATH=%DOTNET_EMSCRIPTEN_NODE_PATH%;%PATH%"
+    )
 )
 
 REM binaryen (wasm-opt, etc)
 if "%DOTNET_EMSCRIPTEN_BINARYEN_ROOT%"=="" (
-echo %DOTNET_EMSCRIPTEN_BINARYEN_ROOT% is empty
-exit /b 1
+    echo %DOTNET_EMSCRIPTEN_BINARYEN_ROOT% is empty
+    exit /b 1
 )
 set "TOADD_PATH_BINARYEN=%DOTNET_EMSCRIPTEN_BINARYEN_ROOT%bin"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_BINARYEN%" (
-if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_BINARYEN%" (
-if not "%TOADD_PATH_NODEJS%"=="%TOADD_PATH_BINARYEN%" (
-echo PATH += %TOADD_PATH_BINARYEN%
-set "PATH=%TOADD_PATH_BINARYEN%;%PATH%"
-)
-)
+    if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_BINARYEN%" (
+        if not "%TOADD_PATH_NODEJS%"=="%TOADD_PATH_BINARYEN%" (
+            echo PATH += %TOADD_PATH_BINARYEN%
+            set "PATH=%TOADD_PATH_BINARYEN%;%PATH%"
+        )
+    )
 )

--- a/eng/emsdk_env.sh
+++ b/eng/emsdk_env.sh
@@ -1,10 +1,61 @@
+CURRENT_SCRIPT=
+DIR="."
+
+# use shell specific method to get the path
+# to the current file being source'd.
+#
+# To add a shell, add another conditional below,
+# then add tests to scripts/test_source_env.sh
+
+if [ -n "${BASH_SOURCE-}" ]; then
+  CURRENT_SCRIPT="$BASH_SOURCE"
+elif [ -n "${ZSH_VERSION-}" ]; then
+  CURRENT_SCRIPT="${(%):-%x}"
+elif [ -n "${KSH_VERSION-}" ]; then
+  CURRENT_SCRIPT=${.sh.file}
+fi
+
+if [ -n "${CURRENT_SCRIPT-}" ]; then
+  DIR=$(dirname "$CURRENT_SCRIPT")
+  if [ -h "$CURRENT_SCRIPT" ]; then
+    # Now work out actual DIR since this is part of a symlink.
+    # Since we can't be sure that readlink or realpath
+    # are available, use tools more likely to be installed.
+    # (This will still fail if sed is not available.)
+    SYMDIR=$(dirname "$(ls -l "$CURRENT_SCRIPT" | sed -n "s/.*-> //p")")
+    if [ -z "$SYMDIR" ]; then
+      SYMDIR="."
+    fi
+    FULLDIR="$DIR/$SYMDIR"
+    DIR=$(cd "$FULLDIR" > /dev/null 2>&1; /bin/pwd)
+    unset SYMDIR
+    unset FULLDIR
+  fi
+fi
+unset CURRENT_SCRIPT
+
+if [ ! -f "$DIR/emscripten/emcmake.py" ]; then
+  echo "Error: unable to determine 'emsdk' directory. Perhaps you are using a shell or" 1>&2
+  echo "       environment that this script does not support." 1>&2
+  echo 1>&2
+  echo "A possible solution is to source this script while in the 'emsdk' directory." 1>&2
+  echo 1>&2
+  unset DIR
+  return
+fi
+export EMSDK_PATH=${DIR}/
+unset DIR
+
+export DOTNET_EMSCRIPTEN_LLVM_ROOT=${EMSDK_PATH}bin/
+export DOTNET_EMSCRIPTEN_NODE_JS=${EMSDK_PATH}node/bin/node
+export DOTNET_EMSCRIPTEN_BINARYEN_ROOT=${EMSDK_PATH}
 #!/bin/bash
 echo "*** .NET EMSDK path setup ***"
 
 # emscripten (emconfigure, em++, etc)
 if [ -z "${EMSDK_PATH}" ]; then
-  echo "\$EMSDK_PATH is empty"
-  exit 1
+echo "/$EMSDK_PATH is empty"
+exit 1
 fi
 TOADD_PATH_EMSCRIPTEN="$(realpath ${EMSDK_PATH}/emscripten)"
 echo "PATH += ${TOADD_PATH_EMSCRIPTEN}"
@@ -12,33 +63,33 @@ export PATH=${TOADD_PATH_EMSCRIPTEN}:$PATH
 
 # llvm (clang, etc)
 if [ -z "${DOTNET_EMSCRIPTEN_LLVM_ROOT}" ]; then
-  echo "\$DOTNET_EMSCRIPTEN_LLVM_ROOT is empty"
-  exit 1
+echo "/$DOTNET_EMSCRIPTEN_LLVM_ROOT is empty"
+exit 1
 fi
 TOADD_PATH_LLVM="$(realpath ${DOTNET_EMSCRIPTEN_LLVM_ROOT})"
 if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_LLVM}" ]; then
-  echo "PATH += ${TOADD_PATH_LLVM}"
-  export PATH=${TOADD_PATH_LLVM}:$PATH
+echo "PATH += ${TOADD_PATH_LLVM}"
+export PATH=${TOADD_PATH_LLVM}:$PATH
 fi
 
 # nodejs (node)
 if [ -z "${DOTNET_EMSCRIPTEN_NODE_JS}" ]; then
-  echo "\$DOTNET_EMSCRIPTEN_NODE_JS is empty"
-  exit 1
+echo "/$DOTNET_EMSCRIPTEN_NODE_JS is empty"
+exit 1
 fi
 TOADD_PATH_NODEJS="$(dirname ${DOTNET_EMSCRIPTEN_NODE_JS})"
 if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_NODEJS}" ] && [ "${TOADD_PATH_LLVM}" != "${TOADD_PATH_NODEJS}" ]; then
-  echo "PATH += ${TOADD_PATH_NODEJS}"
-  export PATH=${TOADD_PATH_NODEJS}:$PATH
+echo "PATH += ${TOADD_PATH_NODEJS}"
+export PATH=${TOADD_PATH_NODEJS}:$PATH
 fi
 
 # binaryen (wasm-opt, etc)
 if [ -z "${DOTNET_EMSCRIPTEN_BINARYEN_ROOT}" ]; then
-  echo "\$DOTNET_EMSCRIPTEN_BINARYEN_ROOT is empty"
-  exit 1
+echo "/$DOTNET_EMSCRIPTEN_BINARYEN_ROOT is empty"
+exit 1
 fi
 TOADD_PATH_BINARYEN="$(realpath ${DOTNET_EMSCRIPTEN_BINARYEN_ROOT}/bin)"
 if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_BINARYEN}" ] && [ "${TOADD_PATH_LLVM}" != "${TOADD_PATH_BINARYEN}" ] && [ "${TOADD_PATH_NODEJS}" != "${TOADD_PATH_BINARYEN}" ]; then
-  echo "PATH += ${TOADD_PATH_BINARYEN}"
-  export PATH=${TOADD_PATH_BINARYEN}:$PATH
+echo "PATH += ${TOADD_PATH_BINARYEN}"
+export PATH=${TOADD_PATH_BINARYEN}:$PATH
 fi


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/105439.

This PR:
- updates emscripten config file directly in emsdk.
- updates `emsdk_env*` scripts.
- Cleans up the scripts.
Best way to read is commit-wise.

After the nuget with this change will get distributed, we will be able to remove `_EmscriptenPaths` from runtime repo, see:
https://github.com/dotnet/runtime/blob/ebbebaca1184940f06df609d5a40096f628200ce/src/mono/mono.proj#L244
```
<WriteLinesToFile File="$(EMSDK_PATH)emscripten/.emscripten"
                      Overwrite="true"
                      Lines="$(_EmscriptenPaths)" /> 
```
etc, done by https://github.com/dotnet/runtime/pull/105612.
This is a non-breaking change, tested locally.

The runtime's changes of the scripts touched here were introduced in https://github.com/dotnet/runtime/pull/100266.