### PR TITLE
Bump downlevel versions to 8.0.8

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
     <EmscriptenVersionNet8>3.1.34</EmscriptenVersionNet8>
     <EmscriptenVersionNet7>3.1.12</EmscriptenVersionNet7>
     <EmscriptenVersionNet6>2.0.23</EmscriptenVersionNet6>
-    <PackageVersionNet8>8.0.7</PackageVersionNet8>
+    <PackageVersionNet8>8.0.8</PackageVersionNet8>
     <PackageVersionNet7>7.0.20</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet8)').Build),25))</PackageVersionNet6>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>9.0.0-alpha.1.24372.2</runtimelinuxarm64MicrosoftNETCoreRuntimeWasmBinaryenTransportVersion>


### PR DESCRIPTION
Port of https://github.com/dotnet/emsdk/pull/842 to main.

Only merge this once 8.0.8 is stable.