### PR TITLE
Allow to use emscripten workload separately

### DIFF
--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.targets.in
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.targets.in
@@ -11,6 +11,9 @@
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(BrowserWorkloadDisabled)' != 'true'">
     <UsingBrowserRuntimeWorkload Condition="'$(RunAOTCompilation)' == 'true' or !('$(UsingMicrosoftNETSdkBlazorWebAssembly)' == 'true' or '$(UsingMicrosoftNETSdkWebAssembly)' == 'true')" >true</UsingBrowserRuntimeWorkload>
     <UsingBrowserRuntimeWorkload Condition="'$(UsingBrowserRuntimeWorkload)' == ''" >$(WasmNativeWorkload)</UsingBrowserRuntimeWorkload>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingEmscriptenWorkload)' == 'true'">
     <CurrentEmsdkTarget Condition="'$(ForceNet8Current)' == 'true'">8.0</CurrentEmsdkTarget>
     <CurrentEmsdkTarget Condition="'$(ForceNet8Current)' != 'true'">9.0</CurrentEmsdkTarget>
   </PropertyGroup>
@@ -20,7 +23,7 @@
     <WasmNativeWorkload>false</WasmNativeWorkload>
   </PropertyGroup>
 
-  <ImportGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '$(CurrentEmsdkTarget)'))">
+  <ImportGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and ('$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingEmscriptenWorkload)' == 'true') and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '$(CurrentEmsdkTarget)'))">
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Python.${NetVersion}" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Node.${NetVersion}" />
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Sdk.${NetVersion}" />


### PR DESCRIPTION
- Include emscripten workload also if `UsingEmscriptenWorkload=true`
- Allows to use emscripten workload for NativeAOT-LLVM without browser workload