### PR TITLE
Sign almost all the things

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,8 +1,0 @@
-;; Exclusions for SignCheck. Corresponds to info in Signing.props.
-;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
-;;
-;; This issue tracks a way to implement exclusions via Signing.props and avoid this extra file: https://github.com/dotnet/arcade/issues/2888
-
-*.js;;Can't dual sign .js files, https://github.com/dotnet/runtime/issues/53252
-*.ps1;;Can't dual sign .ps1 files, https://github.com/dotnet/runtime/issues/53252
-*.exe;*.whl;The .whl files are not supported by ESRP, https://github.com/dotnet/runtime/issues/53252

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -2,5 +2,3 @@
 ;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
 ;;
 ;; This issue tracks a way to implement exclusions via Signing.props and avoid this extra file: https://github.com/dotnet/arcade/issues/2888
-
-*.js;;Can't dual sign .js files, https://github.com/dotnet/runtime/issues/53252

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,0 +1,6 @@
+;; Exclusions for SignCheck. Corresponds to info in Signing.props.
+;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
+;;
+;; This issue tracks a way to implement exclusions via Signing.props and avoid this extra file: https://github.com/dotnet/arcade/issues/2888
+
+*.js;;Can't dual sign .js files, https://github.com/dotnet/runtime/issues/53252

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -2,3 +2,4 @@
 ;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
 ;;
 ;; This issue tracks a way to implement exclusions via Signing.props and avoid this extra file: https://github.com/dotnet/arcade/issues/2888
+*.js;;We don't need to code sign .js files because they are not used in Windows Script Host

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -22,20 +22,7 @@
       Zero length files should not be signed because it breaks signing/ESRP.
     -->
     <FileSignInfo Include="__init__.py" CertificateName="None" />
-    <!-- resolve/test has a lot of zero length files -->
-    <!--
-    <FileSignInfo Include="index.js" CertificateName="None" />
-    <FileSignInfo Include="corejs2-built-ins.js" CertificateName="None" />
-    <FileSignInfo Include="Final_Punctuation.js" CertificateName="None" />
-    <FileSignInfo Include="main.js" CertificateName="None" />
-    <FileSignInfo Include="mug.js" CertificateName="None" />
-    <FileSignInfo Include="doom.js" CertificateName="None" />
-    <FileSignInfo Include="a.js" CertificateName="None" />
-    <FileSignInfo Include="b.js" CertificateName="None" />
-    <FileSignInfo Include="root.js" CertificateName="None" />
-    <FileSignInfo Include="other-lib.js" CertificateName="None" />
-    <FileSignInfo Include="foo.js" CertificateName="None" />
-    -->
+    <FileSignInfo Include="eggs.py" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -12,18 +12,30 @@
     <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
 
     <!--
-      These files can't be dual-signed with 3PartySHA2, don't try to sign them.
+      Script files need to be signed with 3PartyScriptsSHA2 not the dual-signed certificate.
     -->
     <FileExtensionSignInfo Update=".py" CertificateName="3PartyScriptsSHA2" />
     <FileExtensionSignInfo Update=".js" CertificateName="3PartyScriptsSHA2" />
     <FileExtensionSignInfo Update=".ps1" CertificateName="3PartyScriptsSHA2" />
 
     <!--
-      These files are not supported by ESRP, don't try to sign them.
+      Zero length files should not be signed because it breaks signing/ESRP.
     -->
-    <FileSignInfo Include="__init__.py" CertificateName="None" /> <!-- *some* of them are zero length -->
-
-    <!---->
+    <FileSignInfo Include="__init__.py" CertificateName="None" />
+    <!-- resolve/test has a lot of zero length files -->
+    <!--
+    <FileSignInfo Include="index.js" CertificateName="None" />
+    <FileSignInfo Include="corejs2-built-ins.js" CertificateName="None" />
+    <FileSignInfo Include="Final_Punctuation.js" CertificateName="None" />
+    <FileSignInfo Include="main.js" CertificateName="None" />
+    <FileSignInfo Include="mug.js" CertificateName="None" />
+    <FileSignInfo Include="doom.js" CertificateName="None" />
+    <FileSignInfo Include="a.js" CertificateName="None" />
+    <FileSignInfo Include="b.js" CertificateName="None" />
+    <FileSignInfo Include="root.js" CertificateName="None" />
+    <FileSignInfo Include="other-lib.js" CertificateName="None" />
+    <FileSignInfo Include="foo.js" CertificateName="None" />
+    -->
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,9 +15,15 @@
       These files can't be dual-signed with 3PartySHA2, don't try to sign them.
     -->
     <FileExtensionSignInfo Update=".py" CertificateName="3PartyScriptsSHA2" />
-    <FileExtensionSignInfo Update=".js" CertificateName="None" />
+    <FileExtensionSignInfo Update=".js" CertificateName="3PartyScriptsSHA2" />
     <FileExtensionSignInfo Update=".ps1" CertificateName="3PartyScriptsSHA2" />
 
+    <!--
+      These files are not supported by ESRP, don't try to sign them.
+    -->
+    <FileSignInfo Include="__init__.py" CertificateName="None" /> <!-- *some* of them are zero length -->
+
+    <!---->
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -10,14 +10,13 @@
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pyd" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
-    <FileExtensionSignInfo Include=".ps1" CertificateName="3PartyScriptsSHA2" />
 
     <!--
       These files can't be dual-signed with 3PartySHA2, don't try to sign them.
     -->
     <FileExtensionSignInfo Update=".py" CertificateName="3PartyScriptsSHA2" />
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
-    <FileExtensionSignInfo Include=".ps1" CertificateName="3PartyScriptsSHA2" />
+    <FileExtensionSignInfo Update=".ps1" CertificateName="3PartyScriptsSHA2" />
 
   </ItemGroup>
   

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -16,6 +16,10 @@
     -->
     <FileExtensionSignInfo Update=".py" CertificateName="None" />
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
+
+    <FileSignInfo Include="Activate.ps1" CertificateName="None" />
+    <FileSignInfo Include="run_python.ps1" CertificateName="None" />
+    <FileSignInfo Include="run_python_compiler.ps1" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -10,16 +10,15 @@
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pyd" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
+    <FileExtensionSignInfo Include=".ps1" CertificateName="3PartyScriptsSHA2" />
 
     <!--
       These files can't be dual-signed with 3PartySHA2, don't try to sign them.
     -->
-    <FileExtensionSignInfo Update=".py" CertificateName="None" />
+    <FileExtensionSignInfo Update=".py" CertificateName="3PartyScriptsSHA2" />
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
+    <FileExtensionSignInfo Include=".ps1" CertificateName="3PartyScriptsSHA2" />
 
-    <FileSignInfo Include="Activate.ps1" CertificateName="None" />
-    <FileSignInfo Include="run_python.ps1" CertificateName="None" />
-    <FileSignInfo Include="run_python_compiler.ps1" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -10,14 +10,6 @@
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pyd" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
-
-    <!--
-      These files can't be dual-signed with 3PartySHA2, don't try to sign them.
-    -->
-    <FileExtensionSignInfo Update=".py" CertificateName="None" />
-    <FileExtensionSignInfo Update=".ps1" CertificateName="None" />
-    <FileExtensionSignInfo Update=".js" CertificateName="None" />
-    <FileExtensionSignInfo Include=".vbs" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -10,6 +10,12 @@
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".pyd" CertificateName="3PartySHA2" />
     <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
+
+    <!--
+      These files can't be dual-signed with 3PartySHA2, don't try to sign them.
+    -->
+    <FileExtensionSignInfo Update=".py" CertificateName="None" />
+    <FileExtensionSignInfo Update=".js" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -17,7 +17,7 @@
     <FileExtensionSignInfo Update=".py" CertificateName="3PartyScriptsSHA2" />
     <FileExtensionSignInfo Update=".ps1" CertificateName="3PartyScriptsSHA2" />
     <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
-    <FileExtensionSignInfo Include=".js" CertificateName="None" />
+    <FileExtensionSignInfo Update=".js" CertificateName="None" />
 
     <!--
       Zero length files should not be signed because it breaks signing/ESRP.

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,8 +15,9 @@
       Script files need to be signed with 3PartyScriptsSHA2 not the dual-signed certificate.
     -->
     <FileExtensionSignInfo Update=".py" CertificateName="3PartyScriptsSHA2" />
-    <FileExtensionSignInfo Update=".js" CertificateName="3PartyScriptsSHA2" />
     <FileExtensionSignInfo Update=".ps1" CertificateName="3PartyScriptsSHA2" />
+    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
+    <FileExtensionSignInfo Include=".js" CertificateName="None" />
 
     <!--
       Zero length files should not be signed because it breaks signing/ESRP.

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -24,7 +24,6 @@
     -->
     <FileSignInfo Include="__init__.py" CertificateName="None" />
     <FileSignInfo Include="eggs.py" CertificateName="None" />
-    <FileSignInfo Include="Final_Punctuation.js" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -23,6 +23,7 @@
     -->
     <FileSignInfo Include="__init__.py" CertificateName="None" />
     <FileSignInfo Include="eggs.py" CertificateName="None" />
+    <FileSignInfo Include="Final_Punctuation.js" CertificateName="None" />
   </ItemGroup>
   
   <ItemGroup>

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -362,6 +362,6 @@ extends:
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
         enableSourceLinkValidation: false
-        enableSigningValidation: false
+        enableSigningValidation: true
         enableSymbolValidation: false
         enableNugetValidation: true

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -296,7 +296,7 @@
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\ply" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\uglify-js" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\websockify" />
-    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\resolve\test"
+    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\resolve\test" />
 
     <RemoveDir Directories="$(ArtifactsObjDir)node\include" />
     <RemoveDir Directories="$(ArtifactsObjDir)node\lib" />

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -291,12 +291,13 @@
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\google-closure-compiler-osx" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\google-closure-compiler-windows" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\google-closure-compiler-linux" />
+    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\resolve\test" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\closure-compiler" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\jni" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\ply" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\uglify-js" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\websockify" />
-    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\resolve\test" />
+    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\resolve\test" />
 
     <RemoveDir Directories="$(ArtifactsObjDir)node\include" />
     <RemoveDir Directories="$(ArtifactsObjDir)node\lib" />

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -296,6 +296,7 @@
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\ply" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\uglify-js" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\websockify" />
+    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\resolve\test"
 
     <RemoveDir Directories="$(ArtifactsObjDir)node\include" />
     <RemoveDir Directories="$(ArtifactsObjDir)node\lib" />

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -291,13 +291,12 @@
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\google-closure-compiler-osx" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\google-closure-compiler-windows" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\google-closure-compiler-linux" />
-    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\resolve\test" />
+    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\resolve\test" /> <!-- contains zero length .js files -->
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\closure-compiler" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\jni" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\ply" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\uglify-js" />
     <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\third_party\websockify" />
-    <RemoveDir Directories="$(ArtifactsObjDir)upstream\emscripten\node_modules\resolve\test" />
 
     <RemoveDir Directories="$(ArtifactsObjDir)node\include" />
     <RemoveDir Directories="$(ArtifactsObjDir)node\lib" />


### PR DESCRIPTION
The goal here is to sign everything we can.  After much testing the main insight is that 3PartyScriptsSHA2 works for the script files and some of the previously complicated files no longer exist.  There are still a couple of problems:

1.  It is actively wrong to sign the emscripten library js since emscripten uses text transforms to combine it all together so we should test what ends up in the output before merging this.  Because  of this it's likely we'll need to not sign js still.  I don't see a workable way to sign some tooling js and not the library js (perhaps we could sign some files before they are packaged?)
2.  The arcade tooling shouldn't attempt to sign zero length files, it will fail and retry until timeout. There are valid reasons for thing like zero length `__init__.py` files to exist and there is no way to deal with them at the moment. 
3. Because of something unknown that is causing the windows embuilder steps to take unreasonably long (unrelated to this pr) those legs appear to be even more likely to timeout with the additional signing.
