### PR TITLE
Use same AzDO images in the official build as we do in public

### DIFF
--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -66,7 +66,7 @@ stages:
         timeoutInMinutes: 120
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+          demands: ImageOverride -equals 1es-ubuntu-2204-open
         strategy:
           matrix:
             x64:
@@ -103,7 +103,7 @@ stages:
         timeoutInMinutes: 120
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2022.amd64.open
+          demands: ImageOverride -equals 1es-windows-2022-open
         strategy:
           matrix:
             x64:

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -66,7 +66,7 @@ stages:
         timeoutInMinutes: 120
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-2204-open
+          demands: ImageOverride -equals build.ubuntu.2204.amd64.open
         strategy:
           matrix:
             x64:
@@ -103,7 +103,7 @@ stages:
         timeoutInMinutes: 120
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022-open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
         strategy:
           matrix:
             x64:

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -11,9 +11,9 @@ variables:
 - template: /eng/common-variables.yml@self
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 - name: LinuxImage
-  value: 1es-ubuntu-2204
+  value: build.ubuntu.2204.amd64
 - name: WindowsImage
-  value: 1es-windows-2022
+  value: windows.vs2022.amd64
 - name: MacImage
   value: macOS-12
 - name: CheckNuGetSizesScript


### PR DESCRIPTION
We can do this now that the dnceng-provided images contain the 1ES prerequisites.