### PR TITLE
Fix versioned directories for tools in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,15 +49,15 @@
     <BinaryenDir>$(ProjectDir)\binaryen\$(MajorVersion).$(MinorVersion).0</BinaryenDir>
     <HostBinaryenDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(BinaryenDir)</HostBinaryenDir>
     <HostBinaryenDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\binaryen\$(BuildArchitecture)</HostBinaryenDir>
-    <NodeDir>$(ProjectDir)\node\$(MinorVersion).0</NodeDir>
+    <NodeDir>$(ProjectDir)\node\$(MajorVersion).$(MinorVersion).0</NodeDir>
     <HostNodeDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(NodeDir)</HostNodeDir>
     <HostNodeDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\node\$(BuildArchitecture)</HostNodeDir>
-    <PythonDir>$(ProjectDir)\python\$(MinorVersion).0</PythonDir>
+    <PythonDir>$(ProjectDir)\python\$(MajorVersion).$(MinorVersion).0</PythonDir>
     <HostPythonDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(PythonDir)</HostPythonDir>
     <HostPythonDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\python\$(BuildArchitecture)</HostPythonDir>
-    <LLVMDir>$(ProjectDir)\llvm\$(MinorVersion).0</LLVMDir>
+    <LLVMDir>$(ProjectDir)\llvm\$(MajorVersion).$(MinorVersion).0</LLVMDir>
     <HostLLVMDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(LLVMDir)</HostLLVMDir>
     <HostLLVMDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\llvm\$(BuildArchitecture)</HostLLVMDir>
-    <EmscriptenDir>$(ProjectDir)\emscripten\$(MinorVersion).0</EmscriptenDir>
+    <EmscriptenDir>$(ProjectDir)\emscripten\$(MajorVersion).$(MinorVersion).0</EmscriptenDir>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,18 +45,19 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BinaryenDir>$(ProjectDir)\binaryen\$(VersionPrefix)</BinaryenDir>
+    <!-- we're using major.minor.0 version here instead of VersionPrefix so we don't need to bump the versions in emsdk_manifest.json in servicing all the time -->
+    <BinaryenDir>$(ProjectDir)\binaryen\$(MajorVersion).$(MinorVersion).0</BinaryenDir>
     <HostBinaryenDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(BinaryenDir)</HostBinaryenDir>
     <HostBinaryenDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\binaryen\$(BuildArchitecture)</HostBinaryenDir>
-    <NodeDir>$(ProjectDir)\node\$(VersionPrefix)</NodeDir>
+    <NodeDir>$(ProjectDir)\node\$(MinorVersion).0</NodeDir>
     <HostNodeDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(NodeDir)</HostNodeDir>
     <HostNodeDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\node\$(BuildArchitecture)</HostNodeDir>
-    <PythonDir>$(ProjectDir)\python\$(VersionPrefix)</PythonDir>
+    <PythonDir>$(ProjectDir)\python\$(MinorVersion).0</PythonDir>
     <HostPythonDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(PythonDir)</HostPythonDir>
     <HostPythonDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\python\$(BuildArchitecture)</HostPythonDir>
-    <LLVMDir>$(ProjectDir)\llvm\$(VersionPrefix)</LLVMDir>
+    <LLVMDir>$(ProjectDir)\llvm\$(MinorVersion).0</LLVMDir>
     <HostLLVMDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(LLVMDir)</HostLLVMDir>
     <HostLLVMDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\llvm\$(BuildArchitecture)</HostLLVMDir>
-    <EmscriptenDir>$(ProjectDir)\emscripten\$(VersionPrefix)</EmscriptenDir>
+    <EmscriptenDir>$(ProjectDir)\emscripten\$(MinorVersion).0</EmscriptenDir>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
emsdk.py started reading files out of the tool directories but in servicing we aren't bumping the version in emsdk_manifest.json so they weren't found.

Don't include the patch version in the tool directories to fix this.