### PR TITLE
[release/9.0] Treat rtm as stable workload band

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -59,6 +59,10 @@
   <PropertyGroup>
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release' and '$(PrereleaseVersionLabel)' != 'rtm'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
+    <WorkloadVersionSuffix>$(WorkloadVersionSuffix.TrimEnd('.'))</WorkloadVersionSuffix>
+  </PropertyGroup>
   <ItemGroup>
     <WorkloadSdkBandVersions Include="9.0.100" SupportsMachineArch="true" />
   </ItemGroup>

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Common.props
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Common.props
@@ -16,11 +16,6 @@
     <SkipIndexCheck>true</SkipIndexCheck>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
-    <WorkloadVersionSuffix>$(WorkloadVersionSuffix.TrimEnd('.'))</WorkloadVersionSuffix>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageIndex Include="$(PackageIndexFile)" />
   </ItemGroup>


### PR DESCRIPTION
see discussion at https://github.com/dotnet/sdk/pull/43554