### PR TITLE
[workloads] Consider rtm a stable workload band

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -58,6 +58,10 @@
   <PropertyGroup>
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release' and '$(PrereleaseVersionLabel)' != 'rtm'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
+    <WorkloadVersionSuffix>$(WorkloadVersionSuffix.TrimEnd('.'))</WorkloadVersionSuffix>
+  </PropertyGroup>
   <ItemGroup>
     <WorkloadSdkBandVersions Include="10.0.100" SupportsMachineArch="true" />
   </ItemGroup>

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Common.props
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Common.props
@@ -16,10 +16,6 @@
     <SkipIndexCheck>true</SkipIndexCheck>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <WorkloadVersionSuffix Condition="'$(DotNetFinalVersionKind)' != 'release'">-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</WorkloadVersionSuffix>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageIndex Include="$(PackageIndexFile)" />
   </ItemGroup>


### PR DESCRIPTION
Backport of the hotfix in release/9.0