### PR TITLE
Fix TreatPreviousAsCurrent check

### DIFF
--- a/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.targets.in
+++ b/eng/nuget/Microsoft.NET.Workload.Emscripten.Current.Manifest/WorkloadManifest.targets.in
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingEmscriptenWorkload)' == 'true'">
-    <CurrentEmsdkTarget Condition="'$(TreatPreviousAsCurrent)' == '' or '$(TreatPreviousAsCurrent)' == 'true'">9.0</CurrentEmsdkTarget>
-    <CurrentEmsdkTarget Condition="'$(TreatPreviousAsCurrent)' != '' and '$(TreatPreviousAsCurrent)' != 'true'">10.0</CurrentEmsdkTarget>
+    <CurrentEmsdkTarget Condition="'$(TreatPreviousAsCurrent)' == 'true'">9.0</CurrentEmsdkTarget>
+    <CurrentEmsdkTarget Condition="'$(TreatPreviousAsCurrent)' != 'true'">10.0</CurrentEmsdkTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BrowserWorkloadDisabled)' == 'true'">


### PR DESCRIPTION
The `TreatPreviousAsCurrent` is currently empty, but we don't want to treat current as 9.
The possible way to ensure `TreatPreviousAsCurrent` is set before emscripten is imported is to move the property initialization to `AutoImport.props` which always imports before WorkloadManifest.targets