### PR TITLE
Remove source-build related code

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,7 +1,0 @@
-<!-- When altering this file or making other Source Build related changes, include @dotnet/source-build as a reviewer. -->
-<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
-
-<UsageData>
-  <IgnorePatterns>
-  </IgnorePatterns>
-</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -263,17 +263,5 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>03b4b258fc72e5663f2ad701df5d70129aa2df8a</Sha>
     </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="10.0.0-beta.25209.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>03b4b258fc72e5663f2ad701df5d70129aa2df8a</Sha>
-      <SourceBuild RepoName="arcade" ManagedOnly="true" />
-    </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="10.0.620402">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>14f833124983b36ac4083338d0cad6caefce2489</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
-    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -14,7 +14,7 @@
     <EmscriptenPkgVersion>$(MicrosoftNETCoreRuntimeWasmEmscriptenTransportVersion)</EmscriptenPkgVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'">
+  <ItemGroup>
     <PackageReference Include="runtime.$(PackageTargetOS)-$(TargetArchitecture).Microsoft.NETCore.Runtime.Wasm.LLVM.Transport"
                       Version="$(LLVMPkgVersion)"
                       PackageArch="$(TargetArchitecture)"
@@ -55,7 +55,7 @@
     <PackageReference Include="@(_PackageReferenceDeduplicated->Distinct())" />
   </ItemGroup>
 
-  <Target Name="CopyBinaryen" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" BeforeTargets="ReallyBuild">
+  <Target Name="CopyBinaryen" BeforeTargets="ReallyBuild">
     <Message Importance="High" Text="** Copying $(PackageTargetOS)-$(TargetArchitecture) Binaryen to $(BinaryenDir)" />
     <Message Importance="High" Text="** Copying $(PackageHostOS)-$(BuildArchitecture) Binaryen to $(HostBinaryenDir)" Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'" />
     <ItemGroup>
@@ -74,7 +74,7 @@
     </Copy>
   </Target>
 
-  <Target Name="CopyNode" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" BeforeTargets="ReallyBuild">
+  <Target Name="CopyNode" BeforeTargets="ReallyBuild">
     <Message Importance="High" Text="** Copying $(PackageTargetOS)-$(TargetArchitecture) Node to $(NodeDir)" />
     <Message Importance="High" Text="** Copying $(PackageHostOS)-$(BuildArchitecture) Node to $(HostNodeDir)" Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'" />
     <ItemGroup>
@@ -93,7 +93,7 @@
     </Copy>
   </Target>
 
-  <Target Name="CopyPython" BeforeTargets="ReallyBuild" Condition="'$(PackageHostOS)' != 'linux' and '$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'">
+  <Target Name="CopyPython" BeforeTargets="ReallyBuild" Condition="'$(PackageHostOS)' != 'linux'>
     <Message Importance="High" Text="** Copying $(PackageTargetOS)-$(TargetArchitecture) Python to $(PythonDir)" />
     <Message Importance="High" Text="** Copying $(PackageHostOS)-$(BuildArchitecture) Python to $(HostPythonDir)" Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'" />
     <ItemGroup>
@@ -112,7 +112,7 @@
     </Copy>
   </Target>
 
-  <Target Name="CopyLLVM" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" BeforeTargets="ReallyBuild">
+  <Target Name="CopyLLVM" BeforeTargets="ReallyBuild">
     <Message Importance="High" Text="** Copying $(PackageTargetOS)-$(TargetArchitecture) LLVM to $(LLVMDir)" />
     <Message Importance="High" Text="** Copying $(PackageHostOS)-$(BuildArchitecture) LLVM to $(HostLLVMDir)" Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'" />
     <ItemGroup>
@@ -131,7 +131,7 @@
     </Copy>
   </Target>
 
-    <Target Name="CopyEmscripten" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" BeforeTargets="ReallyBuild">
+    <Target Name="CopyEmscripten" BeforeTargets="ReallyBuild">
     <Message Importance="High" Text="** Copying Emscripten to $(EmscriptenDir)" />
     <ItemGroup>
       <EmscriptenPkgFiles Include="$(NuGetPackageRoot)\$([System.String]::Copy(%(PackageReference.Identity)).ToLowerInvariant())\%(PackageReference.Version)\tools\**"
@@ -143,7 +143,7 @@
     </Copy>
   </Target>
 
-  <Target Name="ReallyBuild" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" BeforeTargets="Build">
+  <Target Name="ReallyBuild" BeforeTargets="Build">
     <Error Condition="'$(PackageRID)' == ''" Text="PackageRID needs to be specified, e.g. 'osx-x64'!" />
 
     <PropertyGroup>
@@ -367,32 +367,32 @@
 
   <Target Name="ReallyPack" DependsOnTargets="Build" BeforeTargets="Pack">
     <Message Importance="High" Text="Creating nuget packages..." />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Node\Microsoft.NET.Runtime.Emscripten.Node.pkgproj" Targets="Build" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Python\Microsoft.NET.Runtime.Emscripten.Python.pkgproj" Targets="Build" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true' and '$(UsesPythonFromEmsdk)' == 'true'" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk\Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj" Targets="Build" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" />
-    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Cache\Microsoft.NET.Runtime.Emscripten.Cache.pkgproj" Targets="Build" Condition="'$(ForceBuildManifestOnly)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Node\Microsoft.NET.Runtime.Emscripten.Node.pkgproj" Targets="Build" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Python\Microsoft.NET.Runtime.Emscripten.Python.pkgproj" Targets="Build" Condition="'$(UsesPythonFromEmsdk)' == 'true'" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk\Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj" Targets="Build" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Cache\Microsoft.NET.Runtime.Emscripten.Cache.pkgproj" Targets="Build" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Current.Manifest\Microsoft.NET.Workload.Emscripten.Current.Manifest.pkgproj" 
-             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64') or '$(ForceBuildManifestOnly)' == 'true')"
+             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64'))"
              Targets="Build" 
              Properties="PreReleaseVersionLabel=$(PreReleaseVersionLabel);PreReleaseVersionIteration=$(PreReleaseVersionIteration)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.Current.Manifest\Microsoft.NET.Workload.Emscripten.Current.Manifest.pkgproj" 
-             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64') or '$(ForceBuildManifestOnly)' == 'true')"
+             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64'))"
              Targets="Build"
              Properties="IsUnversionedManifest=true" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.net6.Manifest\Microsoft.NET.Workload.Emscripten.net6.Manifest.pkgproj" 
-             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64') or '$(ForceBuildManifestOnly)' == 'true')"
+             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64'))"
              Targets="Build" 
              Properties="PreReleaseVersionLabel=$(PreReleaseVersionLabel);PreReleaseVersionIteration=$(PreReleaseVersionIteration)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.net7.Manifest\Microsoft.NET.Workload.Emscripten.net7.Manifest.pkgproj" 
-             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64') or '$(ForceBuildManifestOnly)' == 'true')"
+             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64'))"
              Targets="Build" 
              Properties="PreReleaseVersionLabel=$(PreReleaseVersionLabel);PreReleaseVersionIteration=$(PreReleaseVersionIteration)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.net8.Manifest\Microsoft.NET.Workload.Emscripten.net8.Manifest.pkgproj"
-             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64') or '$(ForceBuildManifestOnly)' == 'true')"
+             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64'))"
              Targets="Build"
              Properties="PreReleaseVersionLabel=$(PreReleaseVersionLabel);PreReleaseVersionIteration=$(PreReleaseVersionIteration)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Workload.Emscripten.net9.Manifest\Microsoft.NET.Workload.Emscripten.net9.Manifest.pkgproj"
-             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64') or '$(ForceBuildManifestOnly)' == 'true')"
+             Condition="'$(DotNetBuild)' != 'true' and ('$(AssetManifestOS)' == '' or ('$(AssetManifestOS)' == 'win' and '$(TargetArchitecture)' == 'x64'))"
              Targets="Build"
              Properties="PreReleaseVersionLabel=$(PreReleaseVersionLabel);PreReleaseVersionIteration=$(PreReleaseVersionIteration)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Sdk.Internal\Microsoft.NET.Runtime.Emscripten.Sdk.Internal.pkgproj" Targets="Build" 

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -93,7 +93,7 @@
     </Copy>
   </Target>
 
-  <Target Name="CopyPython" BeforeTargets="ReallyBuild" Condition="'$(PackageHostOS)' != 'linux'>
+  <Target Name="CopyPython" BeforeTargets="ReallyBuild" Condition="'$(PackageHostOS)' != 'linux'">
     <Message Importance="High" Text="** Copying $(PackageTargetOS)-$(TargetArchitecture) Python to $(PythonDir)" />
     <Message Importance="High" Text="** Copying $(PackageHostOS)-$(BuildArchitecture) Python to $(HostPythonDir)" Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'" />
     <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5014

We can do this for emsdk already since emsdk doesn't build in source-build anymore.