### PR TITLE
Fix official build script invocations

### DIFF
--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -48,8 +48,18 @@ stages:
               assetManifestPlatform: arm64
               targetArchitecture: arm64
         steps:
-        - bash: |
-            ./eng/common/cibuild.sh --configuration $(_BuildConfig) /p:TargetArchitecture=$(targetArchitecture) /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+        - bash: build.sh
+            --ci
+            --prepareMachine
+            --configuration $(_BuildConfig)
+            --test
+            --pack
+            /p:TargetArchitecture=$(targetArchitecture)
+            /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform)
+            /p:AssetManifestOS=$(assetManifestOS)
+            /p:PlatformName=$(assetManifestPlatform)
+            $(_InternalBuildArgs)
+            $(_NonWindowsInternalPublishArg)
           displayName: Build
         - publish: artifacts/packages
           artifact: Packages_macOS_$(assetManifestPlatform)
@@ -85,8 +95,18 @@ stages:
               assetManifestPlatform: arm64
               targetArchitecture: arm64
         steps:
-        - bash: |
-            ./eng/common/cibuild.sh --configuration $(_BuildConfig) /p:TargetArchitecture=$(targetArchitecture) /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+        - bash: cibuild.sh
+            --ci
+            --prepareMachine
+            --configuration $(_BuildConfig)
+            --test
+            --pack
+            /p:TargetArchitecture=$(targetArchitecture)
+            /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform)
+            /p:AssetManifestOS=$(assetManifestOS)
+            /p:PlatformName=$(assetManifestPlatform)
+            $(_InternalBuildArgs)
+            $(_NonWindowsInternalPublishArg)
           displayName: Build
         - publish: artifacts/packages
           artifact: Packages_$(assetManifestOS)_$(assetManifestPlatform)
@@ -114,8 +134,21 @@ stages:
               assetManifestPlatform: arm64
               targetArchitecture: arm64
         steps:
-        - script: |
-            .\eng\common\CIBuild.cmd -configuration $(_BuildConfig) /p:TargetArchitecture=$(targetArchitecture) /p:SkipWorkloads=true /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform) /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping $(_InternalBuildArgs)
+        - script: build.cmd
+            -ci
+            -prepareMachine
+            -configuration $(_BuildConfig)
+            -test
+            -pack
+            -sign
+            -publish
+            /p:TargetArchitecture=$(targetArchitecture)
+            /p:SkipWorkloads=true
+            /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform)
+            /p:AssetManifestOS=$(assetManifestOS)
+            /p:PlatformName=$(assetManifestPlatform)
+            /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping
+            $(_InternalBuildArgs)
           displayName: Build and Publish
         - task: CopyFiles@2
           displayName: Prepare job-specific intermediate artifacts subdirectory
@@ -158,8 +191,22 @@ stages:
             path: 'artifacts/packages'
             patterns: |
               IntermediateArtifacts/windows/Shipping/*.*
-        - script: |
-            .\eng\common\CIBuild.cmd -configuration $(_BuildConfig) /p:TargetArchitecture=$(targetArchitecture) /p:SkipBuild=true /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform) /p:AssetManifestFileName=win-workloads.xml /p:AssetManifestOS=$(assetManifestOS) /p:PlatformName=$(assetManifestPlatform) /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\windows\Shipping $(_InternalBuildArgs)
+        - script: build.cmd
+            -ci
+            -prepareMachine
+            -configuration $(_BuildConfig)
+            -test
+            -pack
+            -sign
+            -publish
+            /p:TargetArchitecture=$(targetArchitecture)
+            /p:SkipBuild=true
+            /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform)
+            /p:AssetManifestFileName=win-workloads.xml
+            /p:AssetManifestOS=$(assetManifestOS)
+            /p:PlatformName=$(assetManifestPlatform)
+            /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\windows\Shipping
+            $(_InternalBuildArgs)
           displayName: Build and Publish
         - task: CopyFiles@2
           displayName: Prepare job-specific intermediate artifacts subdirectory

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -48,7 +48,7 @@ stages:
               assetManifestPlatform: arm64
               targetArchitecture: arm64
         steps:
-        - bash: build.sh
+        - bash: ./build.sh
             --ci
             --prepareMachine
             --configuration $(_BuildConfig)
@@ -95,7 +95,7 @@ stages:
               assetManifestPlatform: arm64
               targetArchitecture: arm64
         steps:
-        - bash: cibuild.sh
+        - bash: ./build.sh
             --ci
             --prepareMachine
             --configuration $(_BuildConfig)

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -63,8 +63,16 @@ extends:
               image: $(MacImage)
               os: macOS
             steps:
-            - bash: |
-                ./eng/common/cibuild.sh --configuration $(_BuildConfig) /p:TargetArchitecture=x64 /p:PackageRID=osx-x64 /p:AssetManifestOS=osx /p:PlatformName=x64 $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+            - bash: build.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                --pack
+                /p:TargetArchitecture=x64
+                /p:PackageRID=osx-x64
+                /p:AssetManifestOS=osx
+                /p:PlatformName=x64
+                $(_InternalBuildArgs)
+                $(_NonWindowsInternalPublishArg)
               displayName: Build
             - task: 1ES.PublishPipelineArtifact@1
               inputs:
@@ -84,8 +92,16 @@ extends:
               image: $(MacImage)
               os: macOS
             steps:
-            - bash: |
-                ./eng/common/cibuild.sh --configuration $(_BuildConfig) /p:TargetArchitecture=arm64 /p:PackageRID=osx-arm64 /p:AssetManifestOS=osx /p:PlatformName=arm64 $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+            - bash: build.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                --pack
+                /p:TargetArchitecture=arm64
+                /p:PackageRID=osx-arm64
+                /p:AssetManifestOS=osx
+                /p:PlatformName=arm64
+                $(_InternalBuildArgs)
+                $(_NonWindowsInternalPublishArg)
               displayName: Build
             - task: 1ES.PublishPipelineArtifact@1
               inputs:
@@ -106,8 +122,16 @@ extends:
               image: $(LinuxImage)
               os: linux
             steps:
-            - bash: |
-                ./eng/common/cibuild.sh --configuration $(_BuildConfig) /p:TargetArchitecture=x64 /p:PackageRID=linux-x64 /p:AssetManifestOS=linux /p:PlatformName=x64 $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+            - bash: build.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                --pack
+                /p:TargetArchitecture=x64
+                /p:PackageRID=linux-x64
+                /p:AssetManifestOS=linux
+                /p:PlatformName=x64
+                $(_InternalBuildArgs)
+                $(_NonWindowsInternalPublishArg)
               displayName: Build
             - task: 1ES.PublishPipelineArtifact@1
               inputs:
@@ -127,8 +151,16 @@ extends:
               image: $(LinuxImage)
               os: linux
             steps:
-            - bash: |
-                ./eng/common/cibuild.sh --configuration $(_BuildConfig) /p:TargetArchitecture=arm64 /p:PackageRID=linux-arm64 /p:AssetManifestOS=linux /p:PlatformName=arm64 $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+            - bash: build.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                --pack
+                /p:TargetArchitecture=arm64
+                /p:PackageRID=linux-arm64
+                /p:AssetManifestOS=linux
+                /p:PlatformName=arm64
+                $(_InternalBuildArgs)
+                $(_NonWindowsInternalPublishArg)
               displayName: Build
             - task: 1ES.PublishPipelineArtifact@1
               inputs:
@@ -148,8 +180,16 @@ extends:
               image: $(LinuxImage)
               os: linux
             steps:
-            - bash: |
-                ./eng/common/cibuild.sh --configuration $(_BuildConfig) /p:TargetArchitecture=x64 /p:PackageRID=linux-musl-x64 /p:AssetManifestOS=linux-musl /p:PlatformName=x64 $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+            - bash: build.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                --pack
+                /p:TargetArchitecture=x64
+                /p:PackageRID=linux-musl-x64
+                /p:AssetManifestOS=linux-musl
+                /p:PlatformName=x64
+                $(_InternalBuildArgs)
+                $(_NonWindowsInternalPublishArg)
               displayName: Build
             - task: 1ES.PublishPipelineArtifact@1
               inputs:
@@ -169,8 +209,16 @@ extends:
               image: $(LinuxImage)
               os: linux
             steps:
-            - bash: |
-                ./eng/common/cibuild.sh --configuration $(_BuildConfig) /p:TargetArchitecture=arm64 /p:PackageRID=linux-musl-arm64 /p:AssetManifestOS=linux-musl /p:PlatformName=arm64 $(_InternalBuildArgs) $(_NonWindowsInternalPublishArg)
+            - bash: build.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                --pack
+                /p:TargetArchitecture=arm64
+                /p:PackageRID=linux-musl-arm64
+                /p:AssetManifestOS=linux-musl
+                /p:PlatformName=arm64
+                $(_InternalBuildArgs)
+                $(_NonWindowsInternalPublishArg)
               displayName: Build
             - task: 1ES.PublishPipelineArtifact@1
               inputs:
@@ -191,8 +239,17 @@ extends:
               image: $(WindowsImage)
               os: windows
             steps:
-            - script: |
-                .\eng\common\CIBuild.cmd -configuration $(_BuildConfig) /p:TargetArchitecture=x64 /p:SkipWorkloads=true /p:PackageRID=win-x64 /p:AssetManifestOS=win /p:PlatformName=x64 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping $(_InternalBuildArgs)
+            - script: eng\common\CIBuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                /p:TargetArchitecture=x64
+                /p:SkipWorkloads=true
+                /p:PackageRID=win-x64
+                /p:AssetManifestOS=win
+                /p:PlatformName=x64
+                /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping
+                /p:Test=false
+                $(_InternalBuildArgs)
               displayName: Build
             - task: CopyFiles@2
               displayName: Prepare job-specific intermediate artifacts subdirectory
@@ -222,8 +279,17 @@ extends:
               image: $(WindowsImage)
               os: windows
             steps:
-            - script: |
-                .\eng\common\CIBuild.cmd -configuration $(_BuildConfig) /p:TargetArchitecture=arm64 /p:SkipWorkloads=true /p:PackageRID=win-arm64 /p:AssetManifestOS=win /p:PlatformName=arm64 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping $(_InternalBuildArgs)
+            - script: eng\common\CIBuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                /p:TargetArchitecture=arm64
+                /p:SkipWorkloads=true
+                /p:PackageRID=win-arm64
+                /p:AssetManifestOS=win
+                /p:PlatformName=arm64
+                /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping
+                /p:Test=false
+                $(_InternalBuildArgs)
               displayName: Build
             - task: CopyFiles@2
               displayName: Prepare job-specific intermediate artifacts subdirectory
@@ -316,8 +382,18 @@ extends:
               inputs:
                 artifact: Packages_win_arm64
                 path: 'artifacts/packages'
-            - script: |
-                .\eng\common\CIBuild.cmd -configuration $(_BuildConfig) /p:TargetArchitecture=x64 /p:SkipBuild=true /p:PackageRID=win-x64 /p:AssetManifestFileName=win-workloads.xml /p:AssetManifestOS=win /p:PlatformName=x64 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\windows\Shipping $(_InternalBuildArgs)
+            - script: eng\common\CIBuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                /p:TargetArchitecture=x64
+                /p:SkipBuild=true
+                /p:PackageRID=win-x64
+                /p:AssetManifestFileName=win-workloads.xml
+                /p:AssetManifestOS=win
+                /p:PlatformName=x64
+                /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\windows\Shipping
+                /p:Test=false
+                $(_InternalBuildArgs)
               displayName: Build and Publish
             - task: CopyFiles@2
               displayName: Prepare job-specific intermediate artifacts subdirectory

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -63,7 +63,7 @@ extends:
               image: $(MacImage)
               os: macOS
             steps:
-            - bash: build.sh
+            - bash: ./build.sh
                 --ci
                 --prepareMachine
                 --configuration $(_BuildConfig)
@@ -93,7 +93,7 @@ extends:
               image: $(MacImage)
               os: macOS
             steps:
-            - bash: build.sh
+            - bash: ./build.sh
                 --ci
                 --prepareMachine
                 --configuration $(_BuildConfig)
@@ -124,7 +124,7 @@ extends:
               image: $(LinuxImage)
               os: linux
             steps:
-            - bash: build.sh
+            - bash: ./build.sh
                 --ci
                 --prepareMachine
                 --configuration $(_BuildConfig)
@@ -154,7 +154,7 @@ extends:
               image: $(LinuxImage)
               os: linux
             steps:
-            - bash: build.sh
+            - bash: ./build.sh
                 --ci
                 --prepareMachine
                 --configuration $(_BuildConfig)
@@ -184,7 +184,7 @@ extends:
               image: $(LinuxImage)
               os: linux
             steps:
-            - bash: build.sh
+            - bash: ./build.sh
                 --ci
                 --prepareMachine
                 --configuration $(_BuildConfig)
@@ -214,7 +214,7 @@ extends:
               image: $(LinuxImage)
               os: linux
             steps:
-            - bash: build.sh
+            - bash: ./build.sh
                 --ci
                 --prepareMachine
                 --configuration $(_BuildConfig)

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -64,8 +64,9 @@ extends:
               os: macOS
             steps:
             - bash: build.sh
-                --configuration $(_BuildConfig)
+                --ci
                 --prepareMachine
+                --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=x64
                 /p:PackageRID=osx-x64
@@ -93,8 +94,9 @@ extends:
               os: macOS
             steps:
             - bash: build.sh
-                --configuration $(_BuildConfig)
+                --ci
                 --prepareMachine
+                --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=arm64
                 /p:PackageRID=osx-arm64
@@ -123,8 +125,9 @@ extends:
               os: linux
             steps:
             - bash: build.sh
-                --configuration $(_BuildConfig)
+                --ci
                 --prepareMachine
+                --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=x64
                 /p:PackageRID=linux-x64
@@ -152,8 +155,9 @@ extends:
               os: linux
             steps:
             - bash: build.sh
-                --configuration $(_BuildConfig)
+                --ci
                 --prepareMachine
+                --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=arm64
                 /p:PackageRID=linux-arm64
@@ -181,8 +185,9 @@ extends:
               os: linux
             steps:
             - bash: build.sh
-                --configuration $(_BuildConfig)
+                --ci
                 --prepareMachine
+                --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=x64
                 /p:PackageRID=linux-musl-x64
@@ -210,8 +215,9 @@ extends:
               os: linux
             steps:
             - bash: build.sh
-                --configuration $(_BuildConfig)
+                --ci
                 --prepareMachine
+                --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=arm64
                 /p:PackageRID=linux-musl-arm64
@@ -239,16 +245,19 @@ extends:
               image: $(WindowsImage)
               os: windows
             steps:
-            - script: eng\common\CIBuild.cmd
-                -configuration $(_BuildConfig)
+            - script: build.cmd
+                -ci
                 -prepareMachine
+                -configuration $(_BuildConfig)
+                -pack
+                -sign
+                -publish
                 /p:TargetArchitecture=x64
                 /p:SkipWorkloads=true
                 /p:PackageRID=win-x64
                 /p:AssetManifestOS=win
                 /p:PlatformName=x64
                 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping
-                /p:Test=false
                 $(_InternalBuildArgs)
               displayName: Build
             - task: CopyFiles@2
@@ -279,16 +288,19 @@ extends:
               image: $(WindowsImage)
               os: windows
             steps:
-            - script: eng\common\CIBuild.cmd
-                -configuration $(_BuildConfig)
+            - script: build.cmd
+                -ci
                 -prepareMachine
+                -configuration $(_BuildConfig)
+                -pack
+                -sign
+                -publish
                 /p:TargetArchitecture=arm64
                 /p:SkipWorkloads=true
                 /p:PackageRID=win-arm64
                 /p:AssetManifestOS=win
                 /p:PlatformName=arm64
                 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping
-                /p:Test=false
                 $(_InternalBuildArgs)
               displayName: Build
             - task: CopyFiles@2
@@ -382,9 +394,13 @@ extends:
               inputs:
                 artifact: Packages_win_arm64
                 path: 'artifacts/packages'
-            - script: eng\common\CIBuild.cmd
-                -configuration $(_BuildConfig)
+            - script: build.cmd
+                -ci
                 -prepareMachine
+                -configuration $(_BuildConfig)
+                -pack
+                -sign
+                -publish
                 /p:TargetArchitecture=x64
                 /p:SkipBuild=true
                 /p:PackageRID=win-x64
@@ -392,7 +408,6 @@ extends:
                 /p:AssetManifestOS=win
                 /p:PlatformName=x64
                 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\windows\Shipping
-                /p:Test=false
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - task: CopyFiles@2


### PR DESCRIPTION
The Unix legs shouldn't use cibuild.sh as that unconditionally passes the sign and publish switch in.
Also pass the `prepareMachine` flag in.
Set /p:Test=false when using the CIBuild.cmd script for official builds.