### PR TITLE
Rename PackageRid to TargetRid

### DIFF
--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -55,7 +55,7 @@ stages:
             --test
             --pack
             /p:TargetArchitecture=$(targetArchitecture)
-            /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform)
+            /p:TargetRid=$(assetManifestOS)-$(assetManifestPlatform)
             /p:AssetManifestOS=$(assetManifestOS)
             $(_InternalBuildArgs)
             $(_NonWindowsInternalPublishArg)
@@ -101,7 +101,7 @@ stages:
             --test
             --pack
             /p:TargetArchitecture=$(targetArchitecture)
-            /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform)
+            /p:TargetRid=$(assetManifestOS)-$(assetManifestPlatform)
             /p:AssetManifestOS=$(assetManifestOS)
             $(_InternalBuildArgs)
             $(_NonWindowsInternalPublishArg)
@@ -142,7 +142,7 @@ stages:
             -publish
             /p:TargetArchitecture=$(targetArchitecture)
             /p:SkipWorkloads=true
-            /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform)
+            /p:TargetRid=$(assetManifestOS)-$(assetManifestPlatform)
             /p:AssetManifestOS=$(assetManifestOS)
             /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping
             $(_InternalBuildArgs)
@@ -198,7 +198,7 @@ stages:
             -publish
             /p:TargetArchitecture=$(targetArchitecture)
             /p:SkipBuild=true
-            /p:PackageRID=$(assetManifestOS)-$(assetManifestPlatform)
+            /p:TargetRid=$(assetManifestOS)-$(assetManifestPlatform)
             /p:AssetManifestFileName=win-workloads.xml
             /p:AssetManifestOS=$(assetManifestOS)
             /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\windows\Shipping

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -69,7 +69,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=x64
-                /p:PackageRID=osx-x64
+                /p:TargetRid=osx-x64
                 /p:AssetManifestOS=osx
                 $(_InternalBuildArgs)
                 $(_NonWindowsInternalPublishArg)
@@ -98,7 +98,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=arm64
-                /p:PackageRID=osx-arm64
+                /p:TargetRid=osx-arm64
                 /p:AssetManifestOS=osx
                 $(_InternalBuildArgs)
                 $(_NonWindowsInternalPublishArg)
@@ -128,7 +128,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=x64
-                /p:PackageRID=linux-x64
+                /p:TargetRid=linux-x64
                 /p:AssetManifestOS=linux
                 $(_InternalBuildArgs)
                 $(_NonWindowsInternalPublishArg)
@@ -157,7 +157,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=arm64
-                /p:PackageRID=linux-arm64
+                /p:TargetRid=linux-arm64
                 /p:AssetManifestOS=linux
                 $(_InternalBuildArgs)
                 $(_NonWindowsInternalPublishArg)
@@ -186,7 +186,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=x64
-                /p:PackageRID=linux-musl-x64
+                /p:TargetRid=linux-musl-x64
                 /p:AssetManifestOS=linux-musl
                 $(_InternalBuildArgs)
                 $(_NonWindowsInternalPublishArg)
@@ -215,7 +215,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 /p:TargetArchitecture=arm64
-                /p:PackageRID=linux-musl-arm64
+                /p:TargetRid=linux-musl-arm64
                 /p:AssetManifestOS=linux-musl
                 $(_InternalBuildArgs)
                 $(_NonWindowsInternalPublishArg)
@@ -248,7 +248,7 @@ extends:
                 -publish
                 /p:TargetArchitecture=x64
                 /p:SkipWorkloads=true
-                /p:PackageRID=win-x64
+                /p:TargetRid=win-x64
                 /p:AssetManifestOS=win
                 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping
                 $(_InternalBuildArgs)
@@ -290,7 +290,7 @@ extends:
                 -publish
                 /p:TargetArchitecture=arm64
                 /p:SkipWorkloads=true
-                /p:PackageRID=win-arm64
+                /p:TargetRid=win-arm64
                 /p:AssetManifestOS=win
                 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\Shipping
                 $(_InternalBuildArgs)
@@ -395,7 +395,7 @@ extends:
                 -publish
                 /p:TargetArchitecture=x64
                 /p:SkipBuild=true
-                /p:PackageRID=win-x64
+                /p:TargetRid=win-x64
                 /p:AssetManifestFileName=win-workloads.xml
                 /p:AssetManifestOS=win
                 /p:workloadPackagesPath=$(Build.SourcesDirectory)\artifacts\packages\windows\Shipping

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -144,7 +144,7 @@
   </Target>
 
   <Target Name="ReallyBuild" BeforeTargets="Build">
-    <Error Condition="'$(PackageRID)' == ''" Text="PackageRID needs to be specified, e.g. 'osx-x64'!" />
+    <Error Condition="'$(TargetRid)' == ''" Text="TargetRid needs to be specified, e.g. 'osx-x64'!" />
 
     <PropertyGroup>
       <EmSdkFileName Condition="!$([MSBuild]::IsOSPlatform(Windows))">./emsdk</EmSdkFileName>

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Cache/Microsoft.NET.Runtime.Emscripten.Cache.pkgproj
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Cache/Microsoft.NET.Runtime.Emscripten.Cache.pkgproj
@@ -7,13 +7,13 @@
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" DependsOnTargets="GenerateUnixPermissionsFile" Returns="@(PackageFile)">
     <!-- Override the id to include the Emscripten version -->
     <PropertyGroup>
-      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Cache.$(PackageRID)</Id>
+      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Cache.$(TargetRid)</Id>
     </PropertyGroup>
   </Target>
 
   <PropertyGroup>
-    <PackageDescription>Contains Emscripten SDK system libraries cache for $(PackageRID).</PackageDescription>
-    <Description>Contains Emscripten SDK system libraries cache for $(PackageRID).</Description>
+    <PackageDescription>Contains Emscripten SDK system libraries cache for $(TargetRid).</PackageDescription>
+    <Description>Contains Emscripten SDK system libraries cache for $(TargetRid).</Description>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Node/Microsoft.NET.Runtime.Emscripten.Node.pkgproj
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Node/Microsoft.NET.Runtime.Emscripten.Node.pkgproj
@@ -7,13 +7,13 @@
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" DependsOnTargets="GenerateUnixPermissionsFile" Returns="@(PackageFile)">
     <!-- Override the id to include the Emscripten version -->
     <PropertyGroup>
-      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Node.$(PackageRID)</Id>
+      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Node.$(TargetRid)</Id>
     </PropertyGroup>
   </Target>
 
   <PropertyGroup>
-    <PackageDescription>Contains Emscripten Node binaries for $(PackageRID).</PackageDescription>
-    <Description>Contains Emscripten Node binaries for $(PackageRID).</Description>
+    <PackageDescription>Contains Emscripten Node binaries for $(TargetRid).</PackageDescription>
+    <Description>Contains Emscripten Node binaries for $(TargetRid).</Description>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Python/Microsoft.NET.Runtime.Emscripten.Python.pkgproj
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Python/Microsoft.NET.Runtime.Emscripten.Python.pkgproj
@@ -7,13 +7,13 @@
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" DependsOnTargets="GenerateUnixPermissionsFile" Returns="@(PackageFile)">
     <!-- Override the id to include the Emscripten version -->
     <PropertyGroup>
-      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Python.$(PackageRID)</Id>
+      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Python.$(TargetRid)</Id>
     </PropertyGroup>
   </Target>
 
   <PropertyGroup>
-    <PackageDescription>Contains Emscripten Python binaries for $(PackageRID).</PackageDescription>
-    <Description>Contains Emscripten Python binaries for $(PackageRID).</Description>
+    <PackageDescription>Contains Emscripten Python binaries for $(TargetRid).</PackageDescription>
+    <Description>Contains Emscripten Python binaries for $(TargetRid).</Description>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />

--- a/eng/nuget/Microsoft.NET.Runtime.Emscripten.Sdk/Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj
+++ b/eng/nuget/Microsoft.NET.Runtime.Emscripten.Sdk/Microsoft.NET.Runtime.Emscripten.Sdk.pkgproj
@@ -7,13 +7,13 @@
   <Target Name="_PrepareForPack" BeforeTargets="GetPackageFiles" DependsOnTargets="GenerateUnixPermissionsFile" Returns="@(PackageFile)">
     <!-- Override the id to include the Emscripten version -->
     <PropertyGroup>
-      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Sdk.$(PackageRID)</Id>
+      <Id>Microsoft.NET.Runtime.Emscripten.$(EmscriptenVersion).Sdk.$(TargetRid)</Id>
     </PropertyGroup>
   </Target>
 
   <PropertyGroup>
-    <PackageDescription>Contains Emscripten SDK binaries for $(PackageRID).</PackageDescription>
-    <Description>Contains Emscripten SDK binaries for $(PackageRID).</Description>
+    <PackageDescription>Contains Emscripten SDK binaries for $(TargetRid).</PackageDescription>
+    <Description>Contains Emscripten SDK binaries for $(TargetRid).</Description>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.targets" />


### PR DESCRIPTION
TargetRid is a documented unified-build property and follows the GNU configure terms. It's also automatically passed in by the VMR. This avoids the need to pass PackageRid in additionally in the VMR.