### PR TITLE
Fix prepending python directory to PATH

### DIFF
--- a/eng/emsdk_env.cmd
+++ b/eng/emsdk_env.cmd
@@ -7,7 +7,7 @@ if "%EMSDK_PATH%"=="" (
   exit /b 1
 )
 set "TOADD_PATH_EMSCRIPTEN=%EMSDK_PATH%emscripten"
-echo PATH += %TOADD_PATH_EMSCRIPTEN%
+echo Prepending to PATH: %TOADD_PATH_EMSCRIPTEN%
 set "PATH=%TOADD_PATH_EMSCRIPTEN%;%PATH%"
 
 REM python
@@ -15,8 +15,8 @@ if "%EMSDK_PYTHON%"=="" (
   echo %EMSDK_PYTHON% is empty
   exit /b 1
 )
-set "TOADD_PATH_PYTHON=%EMSDK_PYTHON%"
-echo PATH += %TOADD_PATH_PYTHON%
+for %%i in ("%EMSDK_PYTHON%") do set "TOADD_PATH_PYTHON=%%~dpi"
+echo Prepending to PATH: %TOADD_PATH_PYTHON%
 set "PATH=%TOADD_PATH_PYTHON%;%PATH%"
 
 REM llvm (clang, etc)
@@ -26,7 +26,7 @@ if "%DOTNET_EMSCRIPTEN_LLVM_ROOT%"=="" (
 )
 set "TOADD_PATH_LLVM=%DOTNET_EMSCRIPTEN_LLVM_ROOT%"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_LLVM%" (
-  echo PATH += %TOADD_PATH_LLVM%
+  echo Prepending to PATH: %TOADD_PATH_LLVM%
   set "PATH=%TOADD_PATH_LLVM%;%PATH%"
 )
 
@@ -35,16 +35,11 @@ if "%DOTNET_EMSCRIPTEN_NODE_JS%"=="" (
   echo %DOTNET_EMSCRIPTEN_NODE_JS% is empty
   exit /b 1
 )
-if "%DOTNET_EMSCRIPTEN_NODE_PATH%"=="" (
-  echo %DOTNET_EMSCRIPTEN_NODE_PATH% is empty
-  exit /b 1
-)
-set "TOADD_PATH_NODEJS=%DOTNET_EMSCRIPTEN_NODE_JS%"
+for %%i in ("%DOTNET_EMSCRIPTEN_NODE_JS%") do set "TOADD_PATH_NODEJS=%%~dpi"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_NODEJS%" (
   if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_NODEJS%" (
-    echo NODE PATH += %TOADD_PATH_NODEJS%
+    echo Prepending to PATH: %TOADD_PATH_NODEJS%
     set "PATH=%TOADD_PATH_NODEJS%;%PATH%"
-    set "PATH=%DOTNET_EMSCRIPTEN_NODE_PATH%;%PATH%"
   )
 )
 
@@ -53,11 +48,11 @@ if "%DOTNET_EMSCRIPTEN_BINARYEN_ROOT%"=="" (
   echo %DOTNET_EMSCRIPTEN_BINARYEN_ROOT% is empty
   exit /b 1
 )
-set "TOADD_PATH_BINARYEN=%DOTNET_EMSCRIPTEN_BINARYEN_ROOT%bin"
+set "TOADD_PATH_BINARYEN=%DOTNET_EMSCRIPTEN_BINARYEN_ROOT%bin\"
 if not "%TOADD_PATH_EMSCRIPTEN%"=="%TOADD_PATH_BINARYEN%" (
   if not "%TOADD_PATH_LLVM%"=="%TOADD_PATH_BINARYEN%" (
     if not "%TOADD_PATH_NODEJS%"=="%TOADD_PATH_BINARYEN%" (
-      echo PATH += %TOADD_PATH_BINARYEN%
+      echo Prepending to PATH: %TOADD_PATH_BINARYEN%
       set "PATH=%TOADD_PATH_BINARYEN%;%PATH%"
     )
   )

--- a/eng/emsdk_env.sh
+++ b/eng/emsdk_env.sh
@@ -7,7 +7,7 @@ if [ -z "${EMSDK_PATH}" ]; then
   exit 1
 fi
 TOADD_PATH_EMSCRIPTEN="$(realpath ${EMSDK_PATH}/emscripten)"
-echo "PATH += ${TOADD_PATH_EMSCRIPTEN}"
+echo "Prepending to PATH: ${TOADD_PATH_EMSCRIPTEN}"
 export PATH=${TOADD_PATH_EMSCRIPTEN}:$PATH
 
 # llvm (clang, etc)
@@ -17,7 +17,7 @@ if [ -z "${DOTNET_EMSCRIPTEN_LLVM_ROOT}" ]; then
 fi
 TOADD_PATH_LLVM="$(realpath ${DOTNET_EMSCRIPTEN_LLVM_ROOT})"
 if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_LLVM}" ]; then
-  echo "PATH += ${TOADD_PATH_LLVM}"
+  echo "Prepending to PATH: ${TOADD_PATH_LLVM}"
   export PATH=${TOADD_PATH_LLVM}:$PATH
 fi
 
@@ -28,7 +28,7 @@ if [ -z "${DOTNET_EMSCRIPTEN_NODE_JS}" ]; then
 fi
 TOADD_PATH_NODEJS="$(dirname ${DOTNET_EMSCRIPTEN_NODE_JS})"
 if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_NODEJS}" ] && [ "${TOADD_PATH_LLVM}" != "${TOADD_PATH_NODEJS}" ]; then
-  echo "PATH += ${TOADD_PATH_NODEJS}"
+  echo "Prepending to PATH: ${TOADD_PATH_NODEJS}"
   export PATH=${TOADD_PATH_NODEJS}:$PATH
 fi
 
@@ -39,6 +39,6 @@ if [ -z "${DOTNET_EMSCRIPTEN_BINARYEN_ROOT}" ]; then
 fi
 TOADD_PATH_BINARYEN="$(realpath ${DOTNET_EMSCRIPTEN_BINARYEN_ROOT}/bin)"
 if [ "${TOADD_PATH_EMSCRIPTEN}" != "${TOADD_PATH_BINARYEN}" ] && [ "${TOADD_PATH_LLVM}" != "${TOADD_PATH_BINARYEN}" ] && [ "${TOADD_PATH_NODEJS}" != "${TOADD_PATH_BINARYEN}" ]; then
-  echo "PATH += ${TOADD_PATH_BINARYEN}"
+  echo "Prepending to PATH: ${TOADD_PATH_BINARYEN}"
   export PATH=${TOADD_PATH_BINARYEN}:$PATH
 fi


### PR DESCRIPTION
We were prepending the full path to python.exe to PATH instead of just the directory. This caused us to not actually use our own python, but fallback to a system-installed one, since PATH works with directories.

https://github.com/dotnet/emsdk/pull/735 most likely hit the same issue but since there's no system-installed node this failed and we instead added an _additional_ variable for the node directory.

This is unnecessary, we can just grab the directory from the .exe.

Also fixed the comment that made it sound like we're _appending_ to PATH, we're actually prepending.