### PR TITLE
Add .npmrc for dotnet-public-npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/


### PR DESCRIPTION
To make sure we don't hit public registry.npmjs.org