### PR TITLE
Don't hardcode a version number in emsdk_manifest.json

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,19 +45,18 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- we're using major.minor.0 version here instead of VersionPrefix so we don't need to bump the versions in emsdk_manifest.json in servicing all the time -->
-    <BinaryenDir>$(ProjectDir)\binaryen\$(MajorVersion).$(MinorVersion).0</BinaryenDir>
+    <BinaryenDir>$(ProjectDir)\binaryen\dotnet</BinaryenDir>
     <HostBinaryenDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(BinaryenDir)</HostBinaryenDir>
     <HostBinaryenDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\binaryen\$(BuildArchitecture)</HostBinaryenDir>
-    <NodeDir>$(ProjectDir)\node\$(MajorVersion).$(MinorVersion).0</NodeDir>
+    <NodeDir>$(ProjectDir)\node\dotnet</NodeDir>
     <HostNodeDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(NodeDir)</HostNodeDir>
     <HostNodeDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\node\$(BuildArchitecture)</HostNodeDir>
-    <PythonDir>$(ProjectDir)\python\$(MajorVersion).$(MinorVersion).0</PythonDir>
+    <PythonDir>$(ProjectDir)\python\dotnet</PythonDir>
     <HostPythonDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(PythonDir)</HostPythonDir>
     <HostPythonDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\python\$(BuildArchitecture)</HostPythonDir>
-    <LLVMDir>$(ProjectDir)\llvm\$(MajorVersion).$(MinorVersion).0</LLVMDir>
+    <LLVMDir>$(ProjectDir)\llvm\dotnet</LLVMDir>
     <HostLLVMDir Condition="'$(BuildArchitecture)' == '$(TargetArchitecture)'">$(LLVMDir)</HostLLVMDir>
     <HostLLVMDir Condition="'$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(PackageTargetOS)' != '$(PackageHostOS)'">$(BaseIntermediateOutputPath)\host\llvm\$(BuildArchitecture)</HostLLVMDir>
-    <EmscriptenDir>$(ProjectDir)\emscripten\$(MajorVersion).$(MinorVersion).0</EmscriptenDir>
+    <EmscriptenDir>$(ProjectDir)\emscripten\dotnet</EmscriptenDir>
   </PropertyGroup>
 </Project>

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -2,7 +2,7 @@
   "tools": [
   {
     "id": "llvm",
-    "version": "10.0.0",
+    "version": "dotnet",
     "url": "https://github.com/dotnet/llvm-project.git",
     "custom_is_installed_script": "lie_and_say_yes",
     "only_supports_wasm": true,
@@ -40,7 +40,7 @@
   },
   {
     "id": "node",
-    "version": "10.0.0",
+    "version": "dotnet",
     "activated_path": "%installation_dir%/bin",
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%",
@@ -48,14 +48,14 @@
   },
   {
     "id": "python",
-    "version": "10.0.0",
+    "version": "dotnet",
     "activated_cfg": "PYTHON='%installation_dir%/bin/python3%.exe%'",
     "activated_env": "EMSDK_PYTHON=%installation_dir%/bin/python3;SSL_CERT_FILE=%installation_dir%/lib/python3.11/site-packages/certifi/cacert.pem",
     "custom_is_installed_script": "lie_and_say_yes"
   },
   {
     "id": "emscripten",
-    "version": "10.0.0",
+    "version": "dotnet",
     "append_bitness": false,
     "url": "https://github.com/dotnet/emscripten.git",
     "git_branch": "dotnet/main",
@@ -67,7 +67,7 @@
   },
   {
     "id": "binaryen",
-    "version": "10.0.0",
+    "version": "dotnet",
     "url": "https://github.com/dotnet/binaryen.git",
     "git_branch": "dotnet/main",
     "activated_cfg": "BINARYEN_ROOT='%installation_dir%'",
@@ -81,17 +81,17 @@
   "sdks": [
   {
     "version": "main",
-    "uses": ["python-10.0.0", "llvm-10.0.0", "node-10.0.0", "emscripten-10.0.0", "binaryen-10.0.0"],
+    "uses": ["python-dotnet", "llvm-dotnet", "node-dotnet", "emscripten-dotnet", "binaryen-dotnet"],
     "os": "win"
   },
   {
     "version": "main",
-    "uses": ["python-10.0.0", "llvm-10.0.0", "node-10.0.0", "emscripten-10.0.0", "binaryen-10.0.0"],
+    "uses": ["python-dotnet", "llvm-dotnet", "node-dotnet", "emscripten-dotnet", "binaryen-dotnet"],
     "os": "macos"
   },
   {
     "version": "main",
-    "uses": ["llvm-10.0.0", "emscripten-10.0.0", "binaryen-10.0.0"],
+    "uses": ["llvm-dotnet", "emscripten-dotnet", "binaryen-dotnet"],
     "os": "linux"
   },
   {
@@ -113,7 +113,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-10.0.0", "python-10.0.0", "releases-%releases-tag%-64bit"],
+    "uses": ["node-dotnet", "python-dotnet", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -121,7 +121,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-10.0.0", "python-10.0.0", "releases-%releases-tag%-64bit"],
+    "uses": ["node-dotnet", "python-dotnet", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "arm64",
     "custom_install_script": "emscripten_npm_install"
@@ -129,7 +129,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-10.0.0", "python-10.0.0", "releases-%releases-tag%-64bit"],
+    "uses": ["node-dotnet", "python-dotnet", "releases-%releases-tag%-64bit"],
     "os": "win",
     "arch": "x86_64",
     "custom_install_script": "emscripten_npm_install"
@@ -137,7 +137,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-10.0.0", "python-10.0.0", "releases-%releases-tag%-64bit"],
+    "uses": ["node-dotnet", "python-dotnet", "releases-%releases-tag%-64bit"],
     "os": "win",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"


### PR DESCRIPTION
It's not used anywhere outside of emsdk so we don't need to bump it.