### PR TITLE
Trim LF from EmscriptenVersion and EmscriptenRevision variables

### DIFF
--- a/eng/sdk_files/Emscripten.Sdk.props
+++ b/eng/sdk_files/Emscripten.Sdk.props
@@ -4,8 +4,8 @@
     <EmscriptenUpstreamBinPath>$(EmscriptenSdkToolsPath)bin\</EmscriptenUpstreamBinPath>
     <EmscriptenUpstreamEmscriptenPath>$(EmscriptenSdkToolsPath)emscripten\</EmscriptenUpstreamEmscriptenPath>
 
-    <EmscriptenVersion>$([System.IO.File]::ReadAllText('$(EmscriptenUpstreamEmscriptenPath)\emscripten-version.txt').Replace('&quot;', ''))</EmscriptenVersion>
-    <EmscriptenRevision>$([System.IO.File]::ReadAllText('$(EmscriptenUpstreamEmscriptenPath)\emscripten-revision.txt'))</EmscriptenRevision>
+    <EmscriptenVersion>$([System.IO.File]::ReadAllText('$(EmscriptenUpstreamEmscriptenPath)\emscripten-version.txt').Replace('&quot;', '').Trim())</EmscriptenVersion>
+    <EmscriptenRevision>$([System.IO.File]::ReadAllText('$(EmscriptenUpstreamEmscriptenPath)\emscripten-revision.txt').Trim())</EmscriptenRevision>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Thanks to https://github.com/dotnet/emsdk/pull/393 , it is now possible to reference EmscriptenVersion from csproj and similar files.
This allows referencing the appropriate wasm file for the runtime version within a nuget package.
e.g. https://github.com/yamachu/SharpOpenJTalk/blob/d98afa9f11f9c780f63750ae1ba7c31d9e21097c/library/lang/nuget/SharpOpenJTalk.Lang.props#L10

However, since a line feed (LF, 0x0a) character exists at the end of the file, the variable becomes difficult to use unless `Trim` is applied.
Therefore, I have modified the code to trim the variable at the point where it is defined, making it more intuitive and easier for users to handle.


```sh
$ cat /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.3.1.56.Sdk.osx-arm64/10.0.1/tools/emscripten/emscripten-version.txt|xxd
00000000: 2233 2e31 2e35 3622 0a                   "3.1.56".
$ cat /usr/local/share/dotnet/packs/Microsoft.NET.Runtime.Emscripten.3.1.56.Sdk.osx-arm64/10.0.1/tools/emscripten/emscripten-revision.txt|xxd
00000000: 3537 6232 3162 3866 6463 6265 3365 6262  57b21b8fdcbe3ebb
00000010: 3532 3331 3738 6237 3934 3635 3235 3436  523178b794652546
00000020: 3638 6561 6234 3038 0a                   68eab408.
```