### PR TITLE
Add retry logic to npm ci for transient network failures

### DIFF
--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -197,8 +197,14 @@
       <NpmPath>$(HostNodeDir)/bin:$(PATH)</NpmPath>
       <NpmPath Condition="$([MSBuild]::IsOSPlatform(Windows))">$(HostNodeDir)\bin%3B$(PATH.Replace(';', '%3B'))</NpmPath>
     </PropertyGroup>
+    <!-- Retry npm ci up to 3 times to handle transient network failures (ETIMEDOUT, etc.) -->
+    <PropertyGroup>
+      <NpmCiCommand>$(HostNodeDir)\bin\$(NpmFileName) ci</NpmCiCommand>
+      <NpmCiRetryCommand Condition="$([MSBuild]::IsOSPlatform(Windows))">$(NpmCiCommand) || (echo Retry 1... &amp;&amp; timeout /t 10 /nobreak &gt;nul &amp;&amp; $(NpmCiCommand)) || (echo Retry 2... &amp;&amp; timeout /t 10 /nobreak &gt;nul &amp;&amp; $(NpmCiCommand))</NpmCiRetryCommand>
+      <NpmCiRetryCommand Condition="!$([MSBuild]::IsOSPlatform(Windows))">$(NpmCiCommand) || (echo Retry 1... &amp;&amp; sleep 10 &amp;&amp; $(NpmCiCommand)) || (echo Retry 2... &amp;&amp; sleep 10 &amp;&amp; $(NpmCiCommand))</NpmCiRetryCommand>
+    </PropertyGroup>
     <Exec WorkingDirectory="$(EmscriptenDir)"
-      Command="$(HostNodeDir)\bin\$(NpmFileName) ci"
+      Command="$(NpmCiRetryCommand)"
       IgnoreStandardErrorWarningFormat="true"
       EnvironmentVariables="PATH=$(NpmPath);npm_config_userconfig=$(RepoRoot)\.npmrc" />
 


### PR DESCRIPTION
## Summary

The `npm ci` command in `emsdk.proj` has no retry logic, causing transient network failures (`ETIMEDOUT`, connection refused, etc.) to fail the entire build.

## Problem

Build [2925361](https://dev.azure.com/dnceng/internal/_build/results?buildId=2925361) (main, Mar 12) failed because `npm ci` timed out connecting to Azure blob storage (`vsblob.vsassets.io:443`):

```
npm ERR! code ETIMEDOUT
npm ERR! syscall connect
npm ERR! errno ETIMEDOUT
npm ERR! network request to https://m6xvsblobprodcus342.vsblob.vsassets.io/... failed
```

Unlike HTTP-level errors that npm retries internally via `--fetch-retries`, TCP connection timeouts (`ETIMEDOUT`) are **not** retried by npm.

## Fix

Add a shell-level retry wrapper that attempts `npm ci` up to 3 times with 10-second delays between attempts. Handles both Windows (`timeout /t 10`) and Unix (`sleep 10`).

This is the same pattern used for other transient network operations in the build (e.g., curl retries for wasi-sdk downloads in runtime#125488).

cc @lewing