### PR TITLE
Sign .js files with 3PartyScriptsSHA2 for VS signing compliance

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -8,7 +8,10 @@
     <FileExtensionSignInfo Include=".pyd" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
 
-    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
+    <!-- JS files are customer-modifiable Emscripten toolchain files. They cannot be
+         Authenticode-signed because modifying a signed file breaks the signature.
+         Instead, a catalog file (emscripten-js.cat) is generated and signed to provide
+         integrity verification. See the GenerateCatalogFiles target in eng/emsdk.proj. -->
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
 
     <!--

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -365,6 +365,49 @@
     <Delete Files="@(DeleteCacheFiles)" />
   </Target>
 
+  <!--
+    Generate a catalog (.cat) file covering all .js files in the SDK package.
+    The .js files are customer-modifiable Emscripten toolchain files that cannot be
+    directly Authenticode-signed. The .cat provides integrity verification without
+    preventing modification. Only runs on Windows (makecat.exe is a Windows SDK tool)
+    and only the Windows packs are inserted into VS.
+  -->
+  <Target Name="GenerateCatalogFiles" AfterTargets="ReallyBuild" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <PropertyGroup>
+      <_CdfFile>$(ArtifactsObjDir)emscripten-js.cdf</_CdfFile>
+      <_CatOutputDir>$(ArtifactsObjDir)upstream\emscripten\</_CatOutputDir>
+    </PropertyGroup>
+
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; {
+      $$rootPath = '$(ArtifactsObjDir)upstream'
+      $$cdfPath = '$(_CdfFile)'
+      $$catPath = '$(_CatOutputDir)emscripten-js.cat'
+
+      $$files = Get-ChildItem -Path $$rootPath -Recurse -Filter '*.js' -File
+      $$cdf = @()
+      $$cdf += '[CatalogHeader]'
+      $$cdf += 'Name=' + $$catPath
+      $$cdf += 'CatalogVersion=2'
+      $$cdf += 'HashAlgorithms=SHA256'
+      $$cdf += ''
+      $$cdf += '[CatalogFiles]'
+
+      $$i = 0
+      foreach ($$f in $$files) {
+        $$label = 'js_' + $$i + '_' + ($$f.Name -replace '[^\w\.-]','_')
+        $$cdf += '&lt;hash&gt;' + $$label + '=' + $$f.FullName
+        $$i++
+      }
+
+      $$cdf | Set-Content -Path $$cdfPath -Encoding ASCII
+      Write-Host ('Generated CDF with ' + $$files.Count + ' .js files')
+    }&quot;" StandardOutputImportance="High" />
+
+    <Exec Command="makecat.exe &quot;$(_CdfFile)&quot;" StandardOutputImportance="High" />
+
+    <Message Importance="High" Text="Generated catalog file: $(_CatOutputDir)emscripten-js.cat" />
+  </Target>
+
   <Target Name="ReallyPack" DependsOnTargets="Build" BeforeTargets="Pack">
     <Message Importance="High" Text="Creating nuget packages..." />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Node\Microsoft.NET.Runtime.Emscripten.Node.pkgproj" Targets="Build" />


### PR DESCRIPTION
## Summary

Sign `.js` files in the Emscripten SDK workload packs with `3PartyScriptsSHA2` instead of skipping them (`None`).

## Problem

VS signing scans flag ~14,468 unsigned files across all Emscripten SDK workload packs (.NET 6–10). The `.js` files inside these packs are 3rd-party OSS Emscripten toolchain files shipped inside VS workload pack MSIs. They are currently not signed because `eng/Signing.props` explicitly sets `CertificateName="None"` for `.js` files with the comment "We don't need to code sign .js files because they are not used in Windows Script Host."

While that rationale is correct for script execution, VS signing compliance requires all files in setup packages to be signed regardless of their runtime usage.

## Fix

Changed `FileExtensionSignInfo` for `.js` from `CertificateName="None"` to `CertificateName="3PartyScriptsSHA2"` (cert 135020022), which is the correct certificate for 3rd-party OSS script files per the Signing Cert Guidance wiki.

## Impact

After this change flows through the staging pipeline and into VS, the ~14,468 previously-unsigned `.js` files across all emsdk workload packs will be properly signed.