### PR TITLE
Add catalog signing for .js files for VS signing compliance

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -8,7 +8,10 @@
     <FileExtensionSignInfo Include=".pyd" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
 
-    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
+    <!-- JS files are customer-modifiable Emscripten toolchain files. They cannot be
+         Authenticode-signed because modifying a signed file breaks the signature.
+         Instead, a catalog file (emscripten-js.cat) is generated and signed to provide
+         integrity verification. See the GenerateCatalogFiles target in eng/emsdk.proj. -->
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
 
     <!--

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -375,9 +375,10 @@
   <Target Name="GenerateCatalogFiles" AfterTargets="ReallyBuild" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <PropertyGroup>
       <_CatOutputPath>$(ArtifactsObjDir)upstream\emscripten\emscripten-js.cat</_CatOutputPath>
+      <_ErrorIfMakecatNotFound Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(OfficialBuild)' == 'true'">true</_ErrorIfMakecatNotFound>
     </PropertyGroup>
 
-    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(MSBuildThisFileDirectory)generate-catalog.ps1' -RootPath '$(ArtifactsObjDir)upstream' -CatOutputPath '$(_CatOutputPath)' -WindowsSdkDir '$(WindowsSdkDir)'&quot;" StandardOutputImportance="High" />
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(MSBuildThisFileDirectory)generate-catalog.ps1' -RootPath '$(ArtifactsObjDir)upstream' -CatOutputPath '$(_CatOutputPath)' -WindowsSdkDir '$(WindowsSdkDir)' -ErrorIfMakecatNotFound '$(_ErrorIfMakecatNotFound)'&quot;" StandardOutputImportance="High" />
 
     <Message Importance="High" Text="Generated catalog file: $(_CatOutputPath)" />
   </Target>

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -365,6 +365,23 @@
     <Delete Files="@(DeleteCacheFiles)" />
   </Target>
 
+  <!--
+    Generate a catalog (.cat) file covering all .js files in the SDK package.
+    The .js files are customer-modifiable Emscripten toolchain files that cannot be
+    directly Authenticode-signed. The .cat provides integrity verification without
+    preventing modification. Only runs on Windows (makecat.exe is a Windows SDK tool)
+    and only the Windows packs are inserted into VS.
+  -->
+  <Target Name="GenerateCatalogFiles" AfterTargets="ReallyBuild" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <PropertyGroup>
+      <_CatOutputPath>$(ArtifactsObjDir)upstream\emscripten\emscripten-js.cat</_CatOutputPath>
+    </PropertyGroup>
+
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(MSBuildThisFileDirectory)generate-catalog.ps1' -RootPath '$(ArtifactsObjDir)upstream' -CatOutputPath '$(_CatOutputPath)' -WindowsSdkDir '$(WindowsSdkDir)'&quot;" StandardOutputImportance="High" />
+
+    <Message Importance="High" Text="Generated catalog file: $(_CatOutputPath)" />
+  </Target>
+
   <Target Name="ReallyPack" DependsOnTargets="Build" BeforeTargets="Pack">
     <Message Importance="High" Text="Creating nuget packages..." />
     <MSBuild Projects="$(MSBuildThisFileDirectory)nuget\Microsoft.NET.Runtime.Emscripten.Node\Microsoft.NET.Runtime.Emscripten.Node.pkgproj" Targets="Build" />

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -380,7 +380,7 @@
 
     <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(MSBuildThisFileDirectory)generate-catalog.ps1' -RootPath '$(ArtifactsObjDir)upstream' -CatOutputPath '$(_CatOutputPath)' -WindowsSdkDir '$(WindowsSdkDir)' -ErrorIfMakecatNotFound '$(_ErrorIfMakecatNotFound)'&quot;" StandardOutputImportance="High" />
 
-    <Message Importance="High" Text="Generated catalog file: $(_CatOutputPath)" />
+    <Message Condition="Exists('$(_CatOutputPath)')" Importance="High" Text="Generated catalog file: $(_CatOutputPath)" />
   </Target>
 
   <Target Name="ReallyPack" DependsOnTargets="Build" BeforeTargets="Pack">

--- a/eng/emsdk.proj
+++ b/eng/emsdk.proj
@@ -375,10 +375,10 @@
   <Target Name="GenerateCatalogFiles" AfterTargets="ReallyBuild" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <PropertyGroup>
       <_CatOutputPath>$(ArtifactsObjDir)upstream\emscripten\emscripten-js.cat</_CatOutputPath>
-      <_ErrorIfMakecatNotFound Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(OfficialBuild)' == 'true'">true</_ErrorIfMakecatNotFound>
+      <_ErrorIfMakecatNotFound Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(OfficialBuild)' == 'true'">-ErrorIfMakecatNotFound</_ErrorIfMakecatNotFound>
     </PropertyGroup>
 
-    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(MSBuildThisFileDirectory)generate-catalog.ps1' -RootPath '$(ArtifactsObjDir)upstream' -CatOutputPath '$(_CatOutputPath)' -WindowsSdkDir '$(WindowsSdkDir)' -ErrorIfMakecatNotFound '$(_ErrorIfMakecatNotFound)'&quot;" StandardOutputImportance="High" />
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(MSBuildThisFileDirectory)generate-catalog.ps1' -RootPath '$(ArtifactsObjDir)upstream' -CatOutputPath '$(_CatOutputPath)' -WindowsSdkDir '$(WindowsSdkDir)' $(_ErrorIfMakecatNotFound)&quot;" StandardOutputImportance="High" />
 
     <Message Condition="Exists('$(_CatOutputPath)')" Importance="High" Text="Generated catalog file: $(_CatOutputPath)" />
   </Target>

--- a/eng/generate-catalog.ps1
+++ b/eng/generate-catalog.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+    Generates a catalog definition file (.cdf) and catalog file (.cat) for all .js files
+    in the specified root directory. Used for VS signing compliance - the .js files are
+    customer-modifiable and cannot be directly Authenticode-signed.
+
+.PARAMETER RootPath
+    Root directory to search for .js files recursively.
+
+.PARAMETER CatOutputPath
+    Full path for the output .cat file.
+#>
+param(
+    [Parameter(Mandatory)][string]$RootPath,
+    [Parameter(Mandatory)][string]$CatOutputPath,
+    [string]$WindowsSdkDir = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+$cdfPath = [System.IO.Path]::ChangeExtension($CatOutputPath, '.cdf')
+
+$files = Get-ChildItem -Path $RootPath -Recurse -Filter '*.js' -File
+if ($files.Count -eq 0) {
+    Write-Warning "No .js files found under $RootPath - skipping catalog generation."
+    exit 0
+}
+
+$cdf = @()
+$cdf += '[CatalogHeader]'
+$cdf += "Name=$CatOutputPath"
+$cdf += 'CatalogVersion=2'
+$cdf += 'HashAlgorithms=SHA256'
+$cdf += ''
+$cdf += '[CatalogFiles]'
+
+$i = 0
+foreach ($f in $files) {
+    $label = "js_${i}_" + ($f.Name -replace '[^\w\.-]', '_')
+    $cdf += "<hash>$label=$($f.FullName)"
+    $i++
+}
+
+$cdf | Set-Content -Path $cdfPath -Encoding ASCII
+Write-Host "Generated CDF with $($files.Count) .js files at $cdfPath"
+
+$catDir = [System.IO.Path]::GetDirectoryName($CatOutputPath)
+if (-not (Test-Path $catDir)) {
+    New-Item -ItemType Directory -Path $catDir -Force | Out-Null
+}
+
+# Find makecat.exe - it ships with the Windows SDK and may not be on PATH.
+# Prefer WindowsSdkDir if passed from MSBuild (not available in this repo's build
+# context since it uses Microsoft.Build.Traversal, but may be set in other builds).
+$makecat = $null
+if ($WindowsSdkDir -and (Test-Path $WindowsSdkDir)) {
+    $makecat = Get-ChildItem -Path (Join-Path $WindowsSdkDir 'bin') -Recurse -Filter 'makecat.exe' -File |
+        Where-Object { $_.DirectoryName -match 'x64' } |
+        Sort-Object DirectoryName -Descending |
+        Select-Object -First 1
+}
+
+if (-not $makecat) {
+    $makecat = Get-Command makecat.exe -ErrorAction SilentlyContinue
+}
+
+if (-not $makecat) {
+    # Fallback: search common Windows SDK locations
+    $sdkRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+    if (Test-Path $sdkRoot) {
+        $makecat = Get-ChildItem -Path $sdkRoot -Recurse -Filter 'makecat.exe' -File |
+            Where-Object { $_.DirectoryName -match 'x64' } |
+            Sort-Object DirectoryName -Descending |
+            Select-Object -First 1
+    }
+}
+
+if (-not $makecat) {
+    Write-Warning "makecat.exe not found - skipping catalog generation. Catalog signing requires the Windows SDK."
+    exit 0
+}
+
+$makecatPath = if ($makecat -is [System.Management.Automation.CommandInfo]) { $makecat.Source } else { $makecat.FullName }
+Write-Host "Using makecat.exe at: $makecatPath"
+
+& $makecatPath $cdfPath
+if ($LASTEXITCODE -ne 0) {
+    throw "makecat.exe failed with exit code $LASTEXITCODE"
+}
+
+Write-Host "Generated catalog file: $CatOutputPath"

--- a/eng/generate-catalog.ps1
+++ b/eng/generate-catalog.ps1
@@ -14,7 +14,7 @@ param(
     [Parameter(Mandatory)][string]$RootPath,
     [Parameter(Mandatory)][string]$CatOutputPath,
     [string]$WindowsSdkDir = '',
-    [bool]$ErrorIfMakecatNotFound = $false
+    [switch]$ErrorIfMakecatNotFound
 )
 
 $ErrorActionPreference = 'Stop'

--- a/eng/generate-catalog.ps1
+++ b/eng/generate-catalog.ps1
@@ -13,7 +13,8 @@
 param(
     [Parameter(Mandatory)][string]$RootPath,
     [Parameter(Mandatory)][string]$CatOutputPath,
-    [string]$WindowsSdkDir = ''
+    [string]$WindowsSdkDir = '',
+    [bool]$ErrorIfMakecatNotFound = $false
 )
 
 $ErrorActionPreference = 'Stop'
@@ -76,6 +77,9 @@ if (-not $makecat) {
 }
 
 if (-not $makecat) {
+    if ($ErrorIfMakecatNotFound) {
+        throw "makecat.exe not found. Catalog signing requires the Windows SDK which must be available in CI builds."
+    }
     Write-Warning "makecat.exe not found - skipping catalog generation. Catalog signing requires the Windows SDK."
     exit 0
 }


### PR DESCRIPTION
The .js files in the Emscripten SDK are customer-modifiable toolchain files that cannot be directly Authenticode-signed (modifying a signed file breaks the signature). Instead, generate a .cat catalog file covering all .js files, which is signed with MicrosoftDotNet500 via the existing FileExtensionSignInfo entry for .cat files.

The GenerateCatalogFiles target runs after ReallyBuild on Windows only (makecat.exe is a Windows SDK tool), generates a CDF listing all .js files, produces emscripten-js.cat, and places it in the SDK package directory so it ships alongside the files it covers.

This fixes ~14,468 unsigned .js files flagged by VS signing compliance scans.