### PR TITLE
Add .cab/.vbs to FileExtensionSignInfo for VS signing compliance

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -7,6 +7,8 @@
   <ItemGroup>
     <FileExtensionSignInfo Include=".pyd" CertificateName="MicrosoftDotNet500" />
     <FileExtensionSignInfo Include=".cat" CertificateName="MicrosoftDotNet500" />
+    <FileExtensionSignInfo Include=".cab" CertificateName="MicrosoftDotNet500" />
+    <FileExtensionSignInfo Include=".vbs" CertificateName="MicrosoftDotNet500" />
 
     <!-- JS files are customer-modifiable Emscripten toolchain files. They cannot be
          Authenticode-signed because modifying a signed file breaks the signature.


### PR DESCRIPTION
## Summary

The VS signing scan flags files across 10 `msemscriptenpythonnet*` and 3 `emsdk6manifest*` workload packs (.NET 6-10) as unsigned. All originate from `dotnet/emsdk`.

## Root Cause

`eng/Signing.props` has no `FileExtensionSignInfo` for `.cab` or `.vbs`. Without `.cab`, the Arcade SignTool cannot open MSI containers to sign embedded cabinet archives — this blocks signing of ALL files inside the MSI. Without `.vbs`, CPython VBScript installer scripts remain unsigned.

`.ps1` does NOT need an override — the Arcade SDK already defines a default for `.ps1` (via `.ps1;.psd1;.psm1;.psc1;.py` -> `Microsoft400`, auto-upgraded to `MicrosoftDotNet500` via `UseDotNetCertificate=true`). Once `.cab` lets the SignTool enter the MSI, `.ps1` files are signed automatically.

## Fix

Two new entries in `eng/Signing.props`:

- `FileExtensionSignInfo Include='.cab' CertificateName='MicrosoftDotNet500'`
- `FileExtensionSignInfo Include='.vbs' CertificateName='MicrosoftDotNet500'`

Both use `MicrosoftDotNet500`, consistent with existing `.pyd` and `.cat` entries. `Include` (not `Update`) because `.cab` and `.vbs` are not in Arcade SDK defaults. `MicrosoftDotNet500` (not `3PartyScriptsSHA2`) because `FileExtensionSignInfo` is global — it applies to all files of that extension in the repo, and the repo standard is `MicrosoftDotNet500`.

## Tracking

VS repo bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2949698