### PR TITLE
Use TargetOS instead of AssetManifestOS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,7 +40,7 @@
     <PackageHostOS Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">linux</PackageHostOS>
     <PackageHostOS Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">osx</PackageHostOS>
     <PackageHostOS Condition="'$(OS)' == 'Windows_NT'">win</PackageHostOS>
-    <PackageTargetOS Condition="'$(AssetManifestOS)' != ''">$(AssetManifestOS)</PackageTargetOS>
+    <PackageTargetOS Condition="'$(TargetOS)' != ''">$(TargetOS)</PackageTargetOS>
     <PackageTargetOS Condition="'$(PackageTargetOS)' == ''">$(PackageHostOS)</PackageTargetOS>
   </PropertyGroup>
 

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -37,12 +37,10 @@ stages:
         strategy:
           matrix:
             x64:
-              assetManifestOS: osx
-              assetManifestPlatform: x64
+              targetOS: osx
               targetArchitecture: x64
             arm64:
-              assetManifestOS: osx
-              assetManifestPlatform: arm64
+              targetOS: osx
               targetArchitecture: arm64
         steps:
         - bash: ./build.sh
@@ -51,9 +49,9 @@ stages:
             --configuration $(_BuildConfig)
             --pack
             --publish
+            /p:TargetOS=$(targetOS)
             /p:TargetArchitecture=$(targetArchitecture)
-            /p:TargetRid=$(assetManifestOS)-$(assetManifestPlatform)
-            /p:AssetManifestOS=$(assetManifestOS)
+            /p:TargetRid=$(targetOS)-$(targetArchitecture)
             $(_InternalBuildArgs)
           displayName: Build
         - bash: |
@@ -72,20 +70,16 @@ stages:
         strategy:
           matrix:
             x64:
-              assetManifestOS: linux
-              assetManifestPlatform: x64
+              targetOS: linux
               targetArchitecture: x64
             arm64:
-              assetManifestOS: linux
-              assetManifestPlatform: arm64
+              targetOS: linux
               targetArchitecture: arm64
             x64_musl:
-              assetManifestOS: linux-musl
-              assetManifestPlatform: x64
+              targetOS: linux-musl
               targetArchitecture: x64
             arm64_musl:
-              assetManifestOS: linux-musl
-              assetManifestPlatform: arm64
+              targetOS: linux-musl
               targetArchitecture: arm64
         steps:
         - bash: ./build.sh
@@ -94,9 +88,9 @@ stages:
             --configuration $(_BuildConfig)
             --pack
             --publish
+            /p:TargetOS=$(targetOS)
             /p:TargetArchitecture=$(targetArchitecture)
-            /p:TargetRid=$(assetManifestOS)-$(assetManifestPlatform)
-            /p:AssetManifestOS=$(assetManifestOS)
+            /p:TargetRid=$(targetOS)-$(targetArchitecture)
             $(_InternalBuildArgs)
           displayName: Build and Publish
         - bash: |
@@ -115,12 +109,10 @@ stages:
         strategy:
           matrix:
             x64:
-              assetManifestOS: win
-              assetManifestPlatform: x64
+              targetOS: win
               targetArchitecture: x64
             arm64:
-              assetManifestOS: win
-              assetManifestPlatform: arm64
+              targetOS: win
               targetArchitecture: arm64
         steps:
         - script: build.cmd
@@ -130,9 +122,9 @@ stages:
             -pack
             -publish
             -sign
+            /p:TargetOS=$(targetOS)
             /p:TargetArchitecture=$(targetArchitecture)
-            /p:TargetRid=$(assetManifestOS)-$(assetManifestPlatform)
-            /p:AssetManifestOS=$(assetManifestOS)
+            /p:TargetRid=$(targetOS)-$(targetArchitecture)
             $(_InternalBuildArgs)
           displayName: Build and Publish
         - script: |

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -70,9 +70,9 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 --publish
+                /p:TargetOS=osx
                 /p:TargetArchitecture=x64
                 /p:TargetRid=osx-x64
-                /p:AssetManifestOS=osx
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - bash: |
@@ -99,9 +99,9 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 --publish
+                /p:TargetOS=osx
                 /p:TargetArchitecture=arm64
                 /p:TargetRid=osx-arm64
-                /p:AssetManifestOS=osx
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - bash: |
@@ -129,9 +129,9 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 --publish
+                /p:TargetOS=linux
                 /p:TargetArchitecture=x64
                 /p:TargetRid=linux-x64
-                /p:AssetManifestOS=linux
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - bash: |
@@ -158,9 +158,9 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 --publish
+                /p:TargetOS=linux
                 /p:TargetArchitecture=arm64
                 /p:TargetRid=linux-arm64
-                /p:AssetManifestOS=linux
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - bash: |
@@ -187,9 +187,9 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 --publish
+                /p:TargetOS=linux-musl
                 /p:TargetArchitecture=x64
                 /p:TargetRid=linux-musl-x64
-                /p:AssetManifestOS=linux-musl
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - bash: |
@@ -216,9 +216,9 @@ extends:
                 --configuration $(_BuildConfig)
                 --pack
                 --publish
+                /p:TargetOS=linux-musl
                 /p:TargetArchitecture=arm64
                 /p:TargetRid=linux-musl-arm64
-                /p:AssetManifestOS=linux-musl
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - bash: |
@@ -246,9 +246,9 @@ extends:
                 -configuration $(_BuildConfig)
                 -pack
                 -publish
+                /p:TargetOS=win
                 /p:TargetArchitecture=x64
                 /p:TargetRid=win-x64
-                /p:AssetManifestOS=win
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - script: |
@@ -275,9 +275,9 @@ extends:
                 -configuration $(_BuildConfig)
                 -pack
                 -publish
+                /p:TargetOS=win
                 /p:TargetArchitecture=arm64
                 /p:TargetRid=win-arm64
-                /p:AssetManifestOS=win
                 $(_InternalBuildArgs)
               displayName: Build and Publish
             - script: |


### PR DESCRIPTION
Since emsdk is now built in the VMR we no longer use our own azure-pipelines.yml for the shipping official build. The VMR doesn't pass AssetManifestOS into the build but TargetOS, this meant that we were falling back to PackageHostOS which meant that we incorrectly packaged linux binaries instead of linux-musl.

Fixes https://github.com/dotnet/runtime/issues/121975