### PR TITLE
Enable the Component Governance pull request policy

### DIFF
--- a/.azuredevops/policies/open_source_security_pr_policy.yml
+++ b/.azuredevops/policies/open_source_security_pr_policy.yml
@@ -1,0 +1,11 @@
+name: open_source_security_pr_policy
+description: 'Pull request policy to block introduction of new vulnerable packages.'
+resource: repository
+configuration:
+  componentGovernance:
+    securityPRSettings:
+      enabled: true
+      isBlocking: true
+      branches:
+      - ~default
+      minSeverity: 'High'


### PR DESCRIPTION
## Description

This adds `.azuredevops/policies/open_source_security_pr_policy.yml` so Component Governance scans pull requests against the default branch and blocks new High severity vulnerable packages.