### PR TITLE
Remove Publish-Build-Assets variable group from release/10.0

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -8,7 +8,6 @@ variables:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -6,7 +6,6 @@ variables:
     value: Release
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -6,8 +6,5 @@ variables:
     value: Release
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: DotNet-HelixApi-Access
-    - group: SDL_Settings
     - name: _InternalBuildArgs
       value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `eng/common-variables.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131