### PR TITLE
Remove Publish-Build-Assets variable group from release/8.0

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -32,7 +32,6 @@ variables:
       value: real
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -2,8 +2,6 @@ variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: DotNetCore
-  - name: HelixApiAccessToken
-    value: ''
   - name: _RunAsPublic
     value: True
   - name: _RunAsInternal
@@ -30,9 +28,6 @@ variables:
       value: True
     - name: _SignType
       value: real
-    # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: DotNet-HelixApi-Access
-    - group: SDL_Settings
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) 
         /p:TeamName=$(_TeamName)

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -30,7 +30,6 @@ variables:
       value: True
     - name: _SignType
       value: real
-    # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `eng/common-variables.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131