### PR TITLE
Remove Publish-Build-Assets variable group from release/9.0

### DIFF
--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -26,7 +26,6 @@ variables:
       value: real
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings
     - name: _InternalBuildArgs

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -24,7 +24,6 @@ variables:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _SignType
       value: real
-    # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -2,8 +2,6 @@ variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: DotNetCore
-  - name: HelixApiAccessToken
-    value: ''
   - name: _InternalBuildArgs
     value: ''
   - name: _InternalPublishArg
@@ -24,9 +22,6 @@ variables:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: _SignType
       value: real
-    # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: DotNet-HelixApi-Access
-    - group: SDL_Settings
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) 
         /p:TeamName=$(_TeamName)


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `eng/common-variables.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131