### PR TITLE
Onboard dotnet-emsdk-official to the DefaultDeny network isolation policy

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -31,6 +31,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: DefaultDeny
     sdl:
       tsa:
         enabled: true


### PR DESCRIPTION
Set `settings.networkIsolationPolicy` to `DefaultDeny` in `eng/azure-pipelines.yml` so the official build runs under the 1ES DefaultDeny network isolation policy instead of `Permissive`, which carries a `Global: Allow All` rule and therefore permits arbitrary outbound connections from build agents. No build behavior changes are expected because the latest successful build on every active branch already reports `Policy: Default Deny ... Status = [ COMPLIANT ]` with zero blocked connections on every network isolated job, the required `CFSClean`, `CFSClean2` and `CFSClean3` policies continue to apply from the central policy map, and the macOS jobs do not run network isolation.